### PR TITLE
Add Smithery CLI Installation Instructions & Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Notion MCP Server
-
-[![smithery badge](https://smithery.ai/badge/@suekou/mcp-notion-server)](https://smithery.ai/servers/@suekou/mcp-notion-server)
+[![smithery badge](https://smithery.ai/badge/@suekou/mcp-notion-server)](https://smithery.ai/server/@suekou/mcp-notion-server)
 
 MCP Server for the Notion API, enabling Claude to interact with Notion workspaces.
+
+ 
+### Installing via Smithery
+
+To install [NAME] for Claude Desktop automatically via [Smithery](https://smithery.ai/server/[SERVER_ID]):
+
+```bash
+npx -y @smithery/cli install @suekou/mcp-notion-server --client claude
+```
 
 ## Setup
 
@@ -223,4 +231,3 @@ If you encounter permission errors:
 ## License
 
 This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.
-File to patch: 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Notion MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@suekou/mcp-notion-server)](https://smithery.ai/servers/@suekou/mcp-notion-server)
+
 MCP Server for the Notion API, enabling Claude to interact with Notion workspaces.
 
 ## Setup
@@ -221,3 +223,4 @@ If you encounter permission errors:
 ## License
 
 This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.
+File to patch: 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Notion Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery.

Let me know if any tweaks have to be made!