### PR TITLE
change console type

### DIFF
--- a/notion/src/index.ts
+++ b/notion/src/index.ts
@@ -1075,7 +1075,7 @@ async function main() {
     process.exit(1);
   }
 
-  console.error("Starting Notion MCP Server...");
+  console.info("Starting Notion MCP Server...");
   const server = new Server(
     {
       name: "Notion MCP Server",
@@ -1354,7 +1354,7 @@ async function main() {
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    console.error("Received ListToolsRequest");
+    console.info("Received ListToolsRequest");
     return {
       tools: [
         appendBlockChildrenTool,
@@ -1379,10 +1379,10 @@ async function main() {
   });
 
   const transport = new StdioServerTransport();
-  console.error("Connecting server to transport...");
+  console.info("Connecting server to transport...");
   await server.connect(transport);
 
-  console.error("Notion MCP Server running on stdio");
+  console.info("Notion MCP Server running on stdio");
 }
 
 main().catch((error) => {


### PR DESCRIPTION
ありがたく使わせてもらってます！！

# なにをやったか
- console.errorで出力しなくて良い箇所を、console.infoに変更した

# なぜやったか
- VSCode + Roo Codeだと、errorを出すとMCPでエラーログが出ている扱いとなり、Toolsが見れなくなる。infoにすることで、Toolsが見れるようになる

before
<img width="366" alt="スクリーンショット 2025-03-07 22 39 54" src="https://github.com/user-attachments/assets/3306cd6a-ac85-4d35-8080-4113fec2760c" />
after
<img width="362" alt="スクリーンショット 2025-03-07 22 40 35" src="https://github.com/user-attachments/assets/347ce4eb-01de-4b4b-9d4f-c63c78675ac1" />
