### PR TITLE
chore: Prepare package for public release

### DIFF
--- a/notion/package-lock.json
+++ b/notion/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "notion",
-  "version": "0.1.1",
+  "name": "@suekou/mcp-notion-server",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "notion",
-      "version": "0.1.1",
+      "name": "@suekou/mcp-notion-server",
+      "version": "1.0.1",
+      "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "0.6.0"
+        "@modelcontextprotocol/sdk": "^0.6.1"
       },
       "bin": {
-        "notion": "build/index.js"
+        "mcp-notion-server": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^20.11.24",
@@ -19,9 +20,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-0.6.0.tgz",
-      "integrity": "sha512-9rsDudGhDtMbvxohPoMMyAUOmEzQsOK+XFchh6gZGqo8sx9sBuZQs+CUttXqa8RZXKDaJRCN2tUtgGof7jRkkw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-0.6.1.tgz",
+      "integrity": "sha512-OkVXMix3EIbB5Z6yife2XTrSlOnVvCLR1Kg91I4pYFEsV9RbnoyQVScXCuVhGaZHOnTZgso8lMQN1Po2TadGKQ==",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",

--- a/notion/package.json
+++ b/notion/package.json
@@ -1,14 +1,18 @@
 {
-  "name": "notion",
-  "version": "0.1.1",
-  "description": "A Model Context Protocol server",
-  "private": true,
+  "name": "@suekou/mcp-notion-server",
+  "version": "1.0.1",
+  "description": "MCP server for interacting with Notion API based on Node",
+  "license": "MIT",
+  "author": "Kosuke Suenaga (https://github.com/suekou/mcp-notion-server)",
   "type": "module",
+  "main": "build/index.js",
   "bin": {
-    "notion": "./build/index.js"
+    "mcp-notion-server": "./build/index.js"
   },
   "files": [
-    "build"
+    "build",
+    "Readme.md",
+    "notion"
   ],
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
@@ -17,7 +21,7 @@
     "inspector": "npx @modelcontextprotocol/inspector build/index.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "0.6.0"
+    "@modelcontextprotocol/sdk": "0.6.1"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",


### PR DESCRIPTION
- Rename package to @suekou/mcp-notion-server
- Update version to 1.0.1
- Update MCP SDK dependency to 0.6.1
- Add license and author information
- Configure package for npm publication