### PR TITLE
refactor: Remove unnecessary console logging in Notion MCP server

### DIFF
--- a/notion/package-lock.json
+++ b/notion/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@suekou/mcp-notion-server",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@suekou/mcp-notion-server",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.6.1"

--- a/notion/package.json
+++ b/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suekou/mcp-notion-server",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MCP server for interacting with Notion API based on Node",
   "license": "MIT",
   "author": "Kosuke Suenaga (https://github.com/suekou/mcp-notion-server)",

--- a/notion/src/index.ts
+++ b/notion/src/index.ts
@@ -1075,7 +1075,6 @@ async function main() {
     process.exit(1);
   }
 
-  console.info("Starting Notion MCP Server...");
   const server = new Server(
     {
       name: "Notion MCP Server",
@@ -1354,7 +1353,6 @@ async function main() {
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    console.info("Received ListToolsRequest");
     return {
       tools: [
         appendBlockChildrenTool,
@@ -1379,10 +1377,7 @@ async function main() {
   });
 
   const transport = new StdioServerTransport();
-  console.info("Connecting server to transport...");
   await server.connect(transport);
-
-  console.info("Notion MCP Server running on stdio");
 }
 
 main().catch((error) => {


### PR DESCRIPTION
I removed the normal log messages (console.info) sent to standard output (stdout) because they might be interfering with MCP protocol communication. I believe this resolves the [issue](https://github.com/suekou/mcp-notion-server/issues/18).