### PR TITLE
[WIP]feat: Add Markdown conversion support for Notion API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,56 @@ or
 }
 ```
 
+## Environment Variables
+
+- `NOTION_API_TOKEN` (required): Your Notion API integration token.
+- `NOTION_MARKDOWN_CONVERSION`: Set to "true" to enable experimental Markdown conversion. This can significantly reduce token consumption when viewing content, but may cause issues when trying to edit page content.
+
+## Advanced Configuration
+
+### Markdown Conversion
+
+By default, all responses are returned in JSON format. You can enable experimental Markdown conversion to reduce token consumption:
+
+```json
+{
+  "mcpServers": {
+    "notion": {
+      "command": "npx",
+      "args": ["-y", "@suekou/mcp-notion-server"],
+      "env": {
+        "NOTION_API_TOKEN": "your-integration-token",
+        "NOTION_MARKDOWN_CONVERSION": true
+      }
+    }
+  }
+}
+```
+
+or
+
+```json
+{
+  "mcpServers": {
+    "notion": {
+      "command": "node",
+      "args": ["your-built-file-path"],
+      "env": {
+        "NOTION_API_TOKEN": "your-integration-token",
+        "NOTION_MARKDOWN_CONVERSION": true
+      }
+    }
+  }
+}
+```
+
+When `NOTION_MARKDOWN_CONVERSION` is set to `"true"`, responses will be converted to Markdown format (when `format` parameter is set to `"markdown"`), making them more human-readable and significantly reducing token consumption. However, since this feature is experimental, it may cause issues when trying to edit page content as the original structure is lost in conversion.
+
+You can control the format on a per-request basis by setting the `format` parameter to either `"json"` or `"markdown"` in your tool calls:
+
+- Use `"markdown"` for better readability when only viewing content
+- Use `"json"` when you need to modify the returned content
+
 ## Troubleshooting
 
 If you encounter permission errors:
@@ -68,6 +118,10 @@ If you encounter permission errors:
 3. Confirm the token and configuration are correctly set in `claude_desktop_config.json`.
 
 ## Tools
+
+All tools support the following optional parameter:
+
+- `format` (string, "json" or "markdown", default: "markdown"): Controls the response format. Use "markdown" for human-readable output, "json" for programmatic access to the original data structure. Note: Markdown conversion only works when the `NOTION_MARKDOWN_CONVERSION` environment variable is set to "true".
 
 1. `notion_append_block_children`
 

--- a/notion/package-lock.json
+++ b/notion/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "0.6.1",
-        "vitest": "^3.0.9"
+        "@modelcontextprotocol/sdk": "^1.7.0",
+        "vitest": "3.0.9"
       },
       "bin": {
         "mcp-notion-server": "build/index.js"
@@ -401,14 +401,22 @@
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-0.6.1.tgz",
-      "integrity": "sha512-OkVXMix3EIbB5Z6yife2XTrSlOnVvCLR1Kg91I4pYFEsV9RbnoyQVScXCuVhGaZHOnTZgso8lMQN1Po2TadGKQ==",
-      "license": "MIT",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.7.0.tgz",
+      "integrity": "sha512-IYPe/FLpvF3IZrd/f5p5ffmWhMc3aEMuM2wGJASDqC2Ge7qatVCdbfPx3n/5xFeb19xN0j/911M2AaFuircsWA==",
       "dependencies": {
         "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^4.1.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -765,12 +773,68 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.1.0.tgz",
+      "integrity": "sha512-/hPxh61E+ll0Ujp24Ilm64cykicul1ypfwjVttduAiEdtnJFvLePSrIPk+HMImtNv5270wOGCb1Tns2rybMkoQ==",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.5.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
+      "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/bytes": {
@@ -788,6 +852,33 @@
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -813,6 +904,17 @@
         "node": ">= 16"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -820,6 +922,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/debug": {
@@ -855,10 +985,72 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
       "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ=="
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.1",
@@ -899,6 +1091,11 @@
         "@esbuild/win32-x64": "0.25.1"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -907,12 +1104,148 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.5.tgz",
+      "integrity": "sha512-LT/5J605bx5SNyE+ITBDiM3FxffBiq9un7Vx0EwMDM3vg8sWKx/tO2zC+LMqZ+smAM0F2hblaDZUVZF0te2pSw==",
+      "dependencies": {
+        "eventsource-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.0.tgz",
+      "integrity": "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.0.tgz",
       "integrity": "sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.0.1.tgz",
+      "integrity": "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.0.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "4.3.6",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "^2.0.0",
+        "fresh": "2.0.0",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "methods": "~1.1.2",
+        "mime-types": "^3.0.0",
+        "on-finished": "2.4.1",
+        "once": "1.4.0",
+        "parseurl": "~1.3.3",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "router": "^2.0.0",
+        "safe-buffer": "5.2.1",
+        "send": "^1.1.0",
+        "serve-static": "^2.1.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "^2.0.0",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -926,6 +1259,82 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/http-errors": {
@@ -962,6 +1371,19 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
     "node_modules/loupe": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
@@ -973,6 +1395,60 @@
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.0.tgz",
+      "integrity": "sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==",
+      "dependencies": {
+        "mime-db": "^1.53.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/ms": {
@@ -997,6 +1473,68 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -1014,6 +1552,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "node_modules/pkce-challenge": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
+      "integrity": "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==",
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.3",
@@ -1040,6 +1586,40 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
@@ -1100,17 +1680,180 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
+    "node_modules/router": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.1.0.tgz",
+      "integrity": "sha512-/m/NSLxeYEgWNtyC+WtNHCF7jbGxOibVWKnn+1Psff4dJGOfoXP+MuC/f2CwSmyiHdOIzYnYFp4W6GxWfekaLA==",
+      "dependencies": {
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/send": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.1.0.tgz",
+      "integrity": "sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^0.5.2",
+        "http-errors": "^2.0.0",
+        "mime-types": "^2.1.35",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/send/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.1.0.tgz",
+      "integrity": "sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -1187,6 +1930,19 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.0.tgz",
+      "integrity": "sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
@@ -1213,6 +1969,22 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1391,13 +2163,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-      "license": "MIT",
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/notion/package-lock.json
+++ b/notion/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^0.6.1"
+        "@modelcontextprotocol/sdk": "0.6.1",
+        "vitest": "^3.0.9"
       },
       "bin": {
         "mcp-notion-server": "build/index.js"
@@ -18,6 +19,386 @@
         "@types/node": "^20.11.24",
         "typescript": "^5.3.3"
       }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz",
+      "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.1.tgz",
+      "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz",
+      "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.1.tgz",
+      "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz",
+      "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz",
+      "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz",
+      "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz",
+      "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz",
+      "integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz",
+      "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz",
+      "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz",
+      "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz",
+      "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz",
+      "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz",
+      "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz",
+      "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz",
+      "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
+      "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz",
+      "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz",
+      "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz",
+      "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz",
+      "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz",
+      "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "0.6.1",
@@ -30,14 +411,366 @@
         "zod": "^3.23.8"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.37.0.tgz",
+      "integrity": "sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.37.0.tgz",
+      "integrity": "sha512-6U3SlVyMxezt8Y+/iEBcbp945uZjJwjZimu76xoG7tO1av9VO691z8PkhzQ85ith2I8R2RddEPeSfcbyPfD4hA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.37.0.tgz",
+      "integrity": "sha512-+iTQ5YHuGmPt10NTzEyMPbayiNTcOZDWsbxZYR1ZnmLnZxG17ivrPSWFO9j6GalY0+gV3Jtwrrs12DBscxnlYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.37.0.tgz",
+      "integrity": "sha512-m8W2UbxLDcmRKVjgl5J/k4B8d7qX2EcJve3Sut7YGrQoPtCIQGPH5AMzuFvYRWZi0FVS0zEY4c8uttPfX6bwYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.37.0.tgz",
+      "integrity": "sha512-FOMXGmH15OmtQWEt174v9P1JqqhlgYge/bUjIbiVD1nI1NeJ30HYT9SJlZMqdo1uQFyt9cz748F1BHghWaDnVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.37.0.tgz",
+      "integrity": "sha512-SZMxNttjPKvV14Hjck5t70xS3l63sbVwl98g3FlVVx2YIDmfUIy29jQrsw06ewEYQ8lQSuY9mpAPlmgRD2iSsA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.37.0.tgz",
+      "integrity": "sha512-hhAALKJPidCwZcj+g+iN+38SIOkhK2a9bqtJR+EtyxrKKSt1ynCBeqrQy31z0oWU6thRZzdx53hVgEbRkuI19w==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.37.0.tgz",
+      "integrity": "sha512-jUb/kmn/Gd8epbHKEqkRAxq5c2EwRt0DqhSGWjPFxLeFvldFdHQs/n8lQ9x85oAeVb6bHcS8irhTJX2FCOd8Ag==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.37.0.tgz",
+      "integrity": "sha512-oNrJxcQT9IcbcmKlkF+Yz2tmOxZgG9D9GRq+1OE6XCQwCVwxixYAa38Z8qqPzQvzt1FCfmrHX03E0pWoXm1DqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.37.0.tgz",
+      "integrity": "sha512-pfxLBMls+28Ey2enpX3JvjEjaJMBX5XlPCZNGxj4kdJyHduPBXtxYeb8alo0a7bqOoWZW2uKynhHxF/MWoHaGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.37.0.tgz",
+      "integrity": "sha512-yCE0NnutTC/7IGUq/PUHmoeZbIwq3KRh02e9SfFh7Vmc1Z7atuJRYWhRME5fKgT8aS20mwi1RyChA23qSyRGpA==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.37.0.tgz",
+      "integrity": "sha512-NxcICptHk06E2Lh3a4Pu+2PEdZ6ahNHuK7o6Np9zcWkrBMuv21j10SQDJW3C9Yf/A/P7cutWoC/DptNLVsZ0VQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.37.0.tgz",
+      "integrity": "sha512-PpWwHMPCVpFZLTfLq7EWJWvrmEuLdGn1GMYcm5MV7PaRgwCEYJAwiN94uBuZev0/J/hFIIJCsYw4nLmXA9J7Pw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.37.0.tgz",
+      "integrity": "sha512-DTNwl6a3CfhGTAOYZ4KtYbdS8b+275LSLqJVJIrPa5/JuIufWWZ/QFvkxp52gpmguN95eujrM68ZG+zVxa8zHA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.37.0.tgz",
+      "integrity": "sha512-hZDDU5fgWvDdHFuExN1gBOhCuzo/8TMpidfOR+1cPZJflcEzXdCy1LjnklQdW8/Et9sryOPJAKAQRw8Jq7Tg+A==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.37.0.tgz",
+      "integrity": "sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.37.0.tgz",
+      "integrity": "sha512-E2lPrLKE8sQbY/2bEkVTGDEk4/49UYRVWgj90MY8yPjpnGBQ+Xi1Qnr7b7UIWw1NOggdFQFOLZ8+5CzCiz143w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.37.0.tgz",
+      "integrity": "sha512-Jm7biMazjNzTU4PrQtr7VS8ibeys9Pn29/1bm4ph7CP2kf21950LgN+BaE2mJ1QujnvOc6p54eWWiVvn05SOBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.37.0.tgz",
+      "integrity": "sha512-e3/1SFm1OjefWICB2Ucstg2dxYDkDTZGDYgwufcbsxTHyqQps1UQf33dFEChBNmeSsTOyrjw2JJq0zbG5GF6RA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.37.0.tgz",
+      "integrity": "sha512-LWbXUBwn/bcLx2sSsqy7pK5o+Nr+VCoRoAohfJ5C/aBio9nfJmGQqHAhU6pwxV/RmyTk5AqdySma7uwWGlmeuA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
+    },
     "node_modules/@types/node": {
       "version": "20.17.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
       "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.9.tgz",
+      "integrity": "sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==",
+      "dependencies": {
+        "@vitest/spy": "3.0.9",
+        "@vitest/utils": "3.0.9",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.9.tgz",
+      "integrity": "sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==",
+      "dependencies": {
+        "@vitest/spy": "3.0.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.9.tgz",
+      "integrity": "sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.9.tgz",
+      "integrity": "sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==",
+      "dependencies": {
+        "@vitest/utils": "3.0.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.9.tgz",
+      "integrity": "sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==",
+      "dependencies": {
+        "@vitest/pretty-format": "3.0.9",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.9.tgz",
+      "integrity": "sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.9.tgz",
+      "integrity": "sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==",
+      "dependencies": {
+        "@vitest/pretty-format": "3.0.9",
+        "loupe": "^3.1.3",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/bytes": {
@@ -49,6 +782,37 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -58,6 +822,30 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -65,6 +853,79 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ=="
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz",
+      "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.1",
+        "@esbuild/android-arm": "0.25.1",
+        "@esbuild/android-arm64": "0.25.1",
+        "@esbuild/android-x64": "0.25.1",
+        "@esbuild/darwin-arm64": "0.25.1",
+        "@esbuild/darwin-x64": "0.25.1",
+        "@esbuild/freebsd-arm64": "0.25.1",
+        "@esbuild/freebsd-x64": "0.25.1",
+        "@esbuild/linux-arm": "0.25.1",
+        "@esbuild/linux-arm64": "0.25.1",
+        "@esbuild/linux-ia32": "0.25.1",
+        "@esbuild/linux-loong64": "0.25.1",
+        "@esbuild/linux-mips64el": "0.25.1",
+        "@esbuild/linux-ppc64": "0.25.1",
+        "@esbuild/linux-riscv64": "0.25.1",
+        "@esbuild/linux-s390x": "0.25.1",
+        "@esbuild/linux-x64": "0.25.1",
+        "@esbuild/netbsd-arm64": "0.25.1",
+        "@esbuild/netbsd-x64": "0.25.1",
+        "@esbuild/openbsd-arm64": "0.25.1",
+        "@esbuild/openbsd-x64": "0.25.1",
+        "@esbuild/sunos-x64": "0.25.1",
+        "@esbuild/win32-arm64": "0.25.1",
+        "@esbuild/win32-ia32": "0.25.1",
+        "@esbuild/win32-x64": "0.25.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.0.tgz",
+      "integrity": "sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/http-errors": {
@@ -101,6 +962,86 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/loupe": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug=="
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "node_modules/postcss": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.8",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/raw-body": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
@@ -116,6 +1057,49 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.37.0.tgz",
+      "integrity": "sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==",
+      "dependencies": {
+        "@types/estree": "1.0.6"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.37.0",
+        "@rollup/rollup-android-arm64": "4.37.0",
+        "@rollup/rollup-darwin-arm64": "4.37.0",
+        "@rollup/rollup-darwin-x64": "4.37.0",
+        "@rollup/rollup-freebsd-arm64": "4.37.0",
+        "@rollup/rollup-freebsd-x64": "4.37.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.37.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.37.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.37.0",
+        "@rollup/rollup-linux-arm64-musl": "4.37.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.37.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.37.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.37.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.37.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.37.0",
+        "@rollup/rollup-linux-x64-gnu": "4.37.0",
+        "@rollup/rollup-linux-x64-musl": "4.37.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.37.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.37.0",
+        "@rollup/rollup-win32-x64-msvc": "4.37.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -128,6 +1112,24 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -135,6 +1137,45 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
+      "integrity": "sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA=="
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
+    },
+    "node_modules/tinypool": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -164,7 +1205,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -174,6 +1215,180 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "postcss": "^8.5.3",
+        "rollup": "^4.30.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.9.tgz",
+      "integrity": "sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.0",
+        "es-module-lexer": "^1.6.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.9.tgz",
+      "integrity": "sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==",
+      "dependencies": {
+        "@vitest/expect": "3.0.9",
+        "@vitest/mocker": "3.0.9",
+        "@vitest/pretty-format": "^3.0.9",
+        "@vitest/runner": "3.0.9",
+        "@vitest/snapshot": "3.0.9",
+        "@vitest/spy": "3.0.9",
+        "@vitest/utils": "3.0.9",
+        "chai": "^5.2.0",
+        "debug": "^4.4.0",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinypool": "^1.0.2",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0",
+        "vite-node": "3.0.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.0.9",
+        "@vitest/ui": "3.0.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zod": {

--- a/notion/package-lock.json
+++ b/notion/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@suekou/mcp-notion-server",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@suekou/mcp-notion-server",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "0.6.1",

--- a/notion/package.json
+++ b/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suekou/mcp-notion-server",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "MCP server for interacting with Notion API based on Node",
   "license": "MIT",
   "author": "Kosuke Suenaga (https://github.com/suekou/mcp-notion-server)",

--- a/notion/package.json
+++ b/notion/package.json
@@ -23,7 +23,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "0.6.1",
+    "@modelcontextprotocol/sdk": "^1.7.0",
     "vitest": "3.0.9"
   },
   "devDependencies": {

--- a/notion/package.json
+++ b/notion/package.json
@@ -18,10 +18,13 @@
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "prepare": "npm run build",
     "watch": "tsc --watch",
-    "inspector": "npx @modelcontextprotocol/inspector build/index.js"
+    "inspector": "npx @modelcontextprotocol/inspector build/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "0.6.1"
+    "@modelcontextprotocol/sdk": "0.6.1",
+    "vitest": "3.0.9"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",

--- a/notion/src/client.test.ts
+++ b/notion/src/client.test.ts
@@ -1,0 +1,166 @@
+import { expect, test, describe, vi, beforeEach } from 'vitest';
+import { NotionClientWrapper } from './index.js'; // Import from the module where this class is defined
+import { PageResponse } from './types/index.js';
+
+// Mock convertToMarkdown before importing
+vi.mock('./markdown/index.js', () => ({
+  convertToMarkdown: vi.fn().mockReturnValue('# Test')
+}));
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+describe('NotionClientWrapper', () => {
+  let wrapper: any;
+  
+  beforeEach(() => {
+    // Reset mocks
+    vi.resetAllMocks();
+    
+    // Create client wrapper with test token
+    wrapper = new NotionClientWrapper('test-token');
+    
+    // Mock fetch to return JSON
+    (global.fetch as any).mockImplementation(() => 
+      Promise.resolve({
+        json: () => Promise.resolve({ success: true })
+      })
+    );
+  });
+
+  test('should initialize with correct headers', () => {
+    expect((wrapper as any).headers).toEqual({
+      Authorization: 'Bearer test-token',
+      'Content-Type': 'application/json',
+      'Notion-Version': '2022-06-28',
+    });
+  });
+
+  test('should call appendBlockChildren with correct parameters', async () => {
+    const blockId = 'block123';
+    const children = [{ type: 'paragraph' }];
+    
+    await wrapper.appendBlockChildren(blockId, children);
+    
+    expect(global.fetch).toHaveBeenCalledWith(
+      `https://api.notion.com/v1/blocks/${blockId}/children`,
+      {
+        method: 'PATCH',
+        headers: (wrapper as any).headers,
+        body: JSON.stringify({ children }),
+      }
+    );
+  });
+
+  test('should call retrieveBlock with correct parameters', async () => {
+    const blockId = 'block123';
+    
+    await wrapper.retrieveBlock(blockId);
+    
+    expect(global.fetch).toHaveBeenCalledWith(
+      `https://api.notion.com/v1/blocks/${blockId}`,
+      {
+        method: 'GET',
+        headers: (wrapper as any).headers,
+      }
+    );
+  });
+
+  test('should call retrieveBlockChildren with pagination parameters', async () => {
+    const blockId = 'block123';
+    const startCursor = 'cursor123';
+    const pageSize = 10;
+    
+    await wrapper.retrieveBlockChildren(blockId, startCursor, pageSize);
+    
+    expect(global.fetch).toHaveBeenCalledWith(
+      `https://api.notion.com/v1/blocks/${blockId}/children?start_cursor=${startCursor}&page_size=${pageSize}`,
+      {
+        method: 'GET',
+        headers: (wrapper as any).headers,
+      }
+    );
+  });
+
+  test('should call retrievePage with correct parameters', async () => {
+    const pageId = 'page123';
+    
+    await wrapper.retrievePage(pageId);
+    
+    expect(global.fetch).toHaveBeenCalledWith(
+      `https://api.notion.com/v1/pages/${pageId}`,
+      {
+        method: 'GET',
+        headers: (wrapper as any).headers,
+      }
+    );
+  });
+
+  test('should call updatePageProperties with correct parameters', async () => {
+    const pageId = 'page123';
+    const properties = { title: { title: [{ text: { content: 'New Title' } }] } };
+    
+    await wrapper.updatePageProperties(pageId, properties);
+    
+    expect(global.fetch).toHaveBeenCalledWith(
+      `https://api.notion.com/v1/pages/${pageId}`,
+      {
+        method: 'PATCH',
+        headers: (wrapper as any).headers,
+        body: JSON.stringify({ properties }),
+      }
+    );
+  });
+
+  test('should call queryDatabase with correct parameters', async () => {
+    const databaseId = 'db123';
+    const filter = { property: 'Status', equals: 'Done' };
+    const sorts = [{ property: 'Due Date', direction: 'ascending' }];
+    
+    await wrapper.queryDatabase(databaseId, filter, sorts);
+    
+    expect(global.fetch).toHaveBeenCalledWith(
+      `https://api.notion.com/v1/databases/${databaseId}/query`,
+      {
+        method: 'POST',
+        headers: (wrapper as any).headers,
+        body: JSON.stringify({ filter, sorts }),
+      }
+    );
+  });
+
+  test('should call search with correct parameters', async () => {
+    const query = 'test query';
+    const filter = { property: 'object', value: 'page' };
+    
+    await wrapper.search(query, filter);
+    
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.notion.com/v1/search',
+      {
+        method: 'POST',
+        headers: (wrapper as any).headers,
+        body: JSON.stringify({ query, filter }),
+      }
+    );
+  });
+
+  test('should call toMarkdown method correctly', async () => {
+    // We already mocked the convertToMarkdown at the top of the file
+    const { convertToMarkdown } = await import('./markdown/index.js');
+    
+    const response: PageResponse = {
+        object: 'page',
+        id: 'test',
+        created_time: '2021-01-01T00:00:00.000Z',
+        last_edited_time: '2021-01-01T00:00:00.000Z',
+        parent: {
+          type: 'workspace'
+        },
+        properties: {}
+      };
+    await wrapper.toMarkdown(response);
+    
+    expect(convertToMarkdown).toHaveBeenCalledWith(response);
+  });
+}); 

--- a/notion/src/client.test.ts
+++ b/notion/src/client.test.ts
@@ -1,13 +1,11 @@
 import { expect, test, describe, vi, beforeEach } from 'vitest';
-import { NotionClientWrapper } from './index.js'; // Import from the module where this class is defined
+import { NotionClientWrapper } from './index.js';
 import { PageResponse } from './types/index.js';
 
-// Mock convertToMarkdown before importing
 vi.mock('./markdown/index.js', () => ({
   convertToMarkdown: vi.fn().mockReturnValue('# Test')
 }));
 
-// Mock global fetch
 global.fetch = vi.fn();
 
 describe('NotionClientWrapper', () => {
@@ -146,7 +144,6 @@ describe('NotionClientWrapper', () => {
   });
 
   test('should call toMarkdown method correctly', async () => {
-    // We already mocked the convertToMarkdown at the top of the file
     const { convertToMarkdown } = await import('./markdown/index.js');
     
     const response: PageResponse = {

--- a/notion/src/client.test.ts
+++ b/notion/src/client.test.ts
@@ -1,163 +1,165 @@
-import { expect, test, describe, vi, beforeEach } from 'vitest';
-import { NotionClientWrapper } from './index.js';
-import { PageResponse } from './types/index.js';
+import { expect, test, describe, vi, beforeEach } from "vitest";
+import { NotionClientWrapper } from "./index.js";
+import { PageResponse } from "./types/index.js";
 
-vi.mock('./markdown/index.js', () => ({
-  convertToMarkdown: vi.fn().mockReturnValue('# Test')
+vi.mock("./markdown/index.js", () => ({
+  convertToMarkdown: vi.fn().mockReturnValue("# Test"),
 }));
 
 global.fetch = vi.fn();
 
-describe('NotionClientWrapper', () => {
+describe("NotionClientWrapper", () => {
   let wrapper: any;
-  
+
   beforeEach(() => {
     // Reset mocks
     vi.resetAllMocks();
-    
+
     // Create client wrapper with test token
-    wrapper = new NotionClientWrapper('test-token');
-    
+    wrapper = new NotionClientWrapper("test-token");
+
     // Mock fetch to return JSON
-    (global.fetch as any).mockImplementation(() => 
+    (global.fetch as any).mockImplementation(() =>
       Promise.resolve({
-        json: () => Promise.resolve({ success: true })
+        json: () => Promise.resolve({ success: true }),
       })
     );
   });
 
-  test('should initialize with correct headers', () => {
+  test("should initialize with correct headers", () => {
     expect((wrapper as any).headers).toEqual({
-      Authorization: 'Bearer test-token',
-      'Content-Type': 'application/json',
-      'Notion-Version': '2022-06-28',
+      Authorization: "Bearer test-token",
+      "Content-Type": "application/json",
+      "Notion-Version": "2022-06-28",
     });
   });
 
-  test('should call appendBlockChildren with correct parameters', async () => {
-    const blockId = 'block123';
-    const children = [{ type: 'paragraph' }];
-    
+  test("should call appendBlockChildren with correct parameters", async () => {
+    const blockId = "block123";
+    const children = [{ type: "paragraph" }];
+
     await wrapper.appendBlockChildren(blockId, children);
-    
+
     expect(global.fetch).toHaveBeenCalledWith(
       `https://api.notion.com/v1/blocks/${blockId}/children`,
       {
-        method: 'PATCH',
+        method: "PATCH",
         headers: (wrapper as any).headers,
         body: JSON.stringify({ children }),
       }
     );
   });
 
-  test('should call retrieveBlock with correct parameters', async () => {
-    const blockId = 'block123';
-    
+  test("should call retrieveBlock with correct parameters", async () => {
+    const blockId = "block123";
+
     await wrapper.retrieveBlock(blockId);
-    
+
     expect(global.fetch).toHaveBeenCalledWith(
       `https://api.notion.com/v1/blocks/${blockId}`,
       {
-        method: 'GET',
+        method: "GET",
         headers: (wrapper as any).headers,
       }
     );
   });
 
-  test('should call retrieveBlockChildren with pagination parameters', async () => {
-    const blockId = 'block123';
-    const startCursor = 'cursor123';
+  test("should call retrieveBlockChildren with pagination parameters", async () => {
+    const blockId = "block123";
+    const startCursor = "cursor123";
     const pageSize = 10;
-    
+
     await wrapper.retrieveBlockChildren(blockId, startCursor, pageSize);
-    
+
     expect(global.fetch).toHaveBeenCalledWith(
       `https://api.notion.com/v1/blocks/${blockId}/children?start_cursor=${startCursor}&page_size=${pageSize}`,
       {
-        method: 'GET',
+        method: "GET",
         headers: (wrapper as any).headers,
       }
     );
   });
 
-  test('should call retrievePage with correct parameters', async () => {
-    const pageId = 'page123';
-    
+  test("should call retrievePage with correct parameters", async () => {
+    const pageId = "page123";
+
     await wrapper.retrievePage(pageId);
-    
+
     expect(global.fetch).toHaveBeenCalledWith(
       `https://api.notion.com/v1/pages/${pageId}`,
       {
-        method: 'GET',
+        method: "GET",
         headers: (wrapper as any).headers,
       }
     );
   });
 
-  test('should call updatePageProperties with correct parameters', async () => {
-    const pageId = 'page123';
-    const properties = { title: { title: [{ text: { content: 'New Title' } }] } };
-    
+  test("should call updatePageProperties with correct parameters", async () => {
+    const pageId = "page123";
+    const properties = {
+      title: { title: [{ text: { content: "New Title" } }] },
+    };
+
     await wrapper.updatePageProperties(pageId, properties);
-    
+
     expect(global.fetch).toHaveBeenCalledWith(
       `https://api.notion.com/v1/pages/${pageId}`,
       {
-        method: 'PATCH',
+        method: "PATCH",
         headers: (wrapper as any).headers,
         body: JSON.stringify({ properties }),
       }
     );
   });
 
-  test('should call queryDatabase with correct parameters', async () => {
-    const databaseId = 'db123';
-    const filter = { property: 'Status', equals: 'Done' };
-    const sorts = [{ property: 'Due Date', direction: 'ascending' }];
-    
+  test("should call queryDatabase with correct parameters", async () => {
+    const databaseId = "db123";
+    const filter = { property: "Status", equals: "Done" };
+    const sorts = [{ property: "Due Date", direction: "ascending" }];
+
     await wrapper.queryDatabase(databaseId, filter, sorts);
-    
+
     expect(global.fetch).toHaveBeenCalledWith(
       `https://api.notion.com/v1/databases/${databaseId}/query`,
       {
-        method: 'POST',
+        method: "POST",
         headers: (wrapper as any).headers,
         body: JSON.stringify({ filter, sorts }),
       }
     );
   });
 
-  test('should call search with correct parameters', async () => {
-    const query = 'test query';
-    const filter = { property: 'object', value: 'page' };
-    
+  test("should call search with correct parameters", async () => {
+    const query = "test query";
+    const filter = { property: "object", value: "page" };
+
     await wrapper.search(query, filter);
-    
+
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://api.notion.com/v1/search',
+      "https://api.notion.com/v1/search",
       {
-        method: 'POST',
+        method: "POST",
         headers: (wrapper as any).headers,
         body: JSON.stringify({ query, filter }),
       }
     );
   });
 
-  test('should call toMarkdown method correctly', async () => {
-    const { convertToMarkdown } = await import('./markdown/index.js');
-    
+  test("should call toMarkdown method correctly", async () => {
+    const { convertToMarkdown } = await import("./markdown/index.js");
+
     const response: PageResponse = {
-        object: 'page',
-        id: 'test',
-        created_time: '2021-01-01T00:00:00.000Z',
-        last_edited_time: '2021-01-01T00:00:00.000Z',
-        parent: {
-          type: 'workspace'
-        },
-        properties: {}
-      };
+      object: "page",
+      id: "test",
+      created_time: "2021-01-01T00:00:00.000Z",
+      last_edited_time: "2021-01-01T00:00:00.000Z",
+      parent: {
+        type: "workspace",
+      },
+      properties: {},
+    };
     await wrapper.toMarkdown(response);
-    
+
     expect(convertToMarkdown).toHaveBeenCalledWith(response);
   });
-}); 
+});

--- a/notion/src/index.ts
+++ b/notion/src/index.ts
@@ -8,15 +8,15 @@ import {
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import { convertToMarkdown } from "./markdown/index.js";
-import { 
-  NotionResponse, 
-  BlockResponse, 
-  PageResponse, 
+import {
+  NotionResponse,
+  BlockResponse,
+  PageResponse,
   DatabaseResponse,
   ListResponse,
   UserResponse,
   CommentResponse,
-  RichTextItemResponse 
+  RichTextItemResponse,
 } from "./types/index.js";
 
 // Type definitions for tool arguments
@@ -125,7 +125,8 @@ interface SearchArgs {
   page_size?: number;
 }
 
-const commonIdDescription = "It should be a 32-character string (excluding hyphens) formatted as 8-4-4-4-12 with hyphens (-).";
+const commonIdDescription =
+  "It should be a 32-character string (excluding hyphens) formatted as 8-4-4-4-12 with hyphens (-).";
 
 // common object schema
 const richTextObjectSchema = {
@@ -269,8 +270,7 @@ const richTextObjectSchema = {
             },
             id: {
               type: "string",
-              description:
-                "The ID of the user." + commonIdDescription,
+              description: "The ID of the user." + commonIdDescription,
             },
           },
           required: ["object", "id"],
@@ -402,7 +402,7 @@ const blockObjectSchema = {
     },
   },
   required: ["object", "type"],
-}
+};
 
 // TODO: If modifications are made, since the original source information is necessary, add an explanation that retrieves the raw object that has not been converted to markdown, and create a dedicated tool to convert to markdown.
 // Tool definitions
@@ -416,8 +416,7 @@ const appendBlockChildrenTool: Tool = {
     properties: {
       block_id: {
         type: "string",
-        description:
-          "The ID of the parent block." + commonIdDescription,
+        description: "The ID of the parent block." + commonIdDescription,
       },
       children: {
         type: "array",
@@ -428,7 +427,8 @@ const appendBlockChildrenTool: Tool = {
       after: {
         type: "string",
         description:
-          "The ID of the existing block that the new block should be appended after." + commonIdDescription,
+          "The ID of the existing block that the new block should be appended after." +
+          commonIdDescription,
       },
     },
     required: ["block_id", "children"],
@@ -443,8 +443,7 @@ const retrieveBlockTool: Tool = {
     properties: {
       block_id: {
         type: "string",
-        description:
-          "The ID of the block to retrieve." + commonIdDescription,
+        description: "The ID of the block to retrieve." + commonIdDescription,
       },
     },
     required: ["block_id"],
@@ -459,8 +458,7 @@ const retrieveBlockChildrenTool: Tool = {
     properties: {
       block_id: {
         type: "string",
-        description:
-          "The ID of the block." + commonIdDescription,
+        description: "The ID of the block." + commonIdDescription,
       },
       start_cursor: {
         type: "string",
@@ -483,8 +481,7 @@ const deleteBlockTool: Tool = {
     properties: {
       block_id: {
         type: "string",
-        description:
-          "The ID of the block to delete." + commonIdDescription,
+        description: "The ID of the block to delete." + commonIdDescription,
       },
     },
     required: ["block_id"],
@@ -500,8 +497,7 @@ const retrievePageTool: Tool = {
     properties: {
       page_id: {
         type: "string",
-        description:
-          "The ID of the page to retrieve." + commonIdDescription,
+        description: "The ID of the page to retrieve." + commonIdDescription,
       },
     },
     required: ["page_id"],
@@ -517,7 +513,8 @@ const updatePagePropertiesTool: Tool = {
       page_id: {
         type: "string",
         description:
-          "The ID of the page or database item to update." + commonIdDescription,
+          "The ID of the page or database item to update." +
+          commonIdDescription,
       },
       properties: {
         type: "object",
@@ -558,8 +555,7 @@ const retrieveUserTool: Tool = {
     properties: {
       user_id: {
         type: "string",
-        description:
-          "The ID of the user to retrieve." + commonIdDescription,
+        description: "The ID of the user to retrieve." + commonIdDescription,
       },
     },
     required: ["user_id"],
@@ -611,8 +607,7 @@ const queryDatabaseTool: Tool = {
     properties: {
       database_id: {
         type: "string",
-        description:
-          "The ID of the database to query." + commonIdDescription,
+        description: "The ID of the database to query." + commonIdDescription,
       },
       filter: {
         type: "object",
@@ -659,8 +654,7 @@ const updateDatabaseTool: Tool = {
     properties: {
       database_id: {
         type: "string",
-        description:
-          "The ID of the database to update." + commonIdDescription,
+        description: "The ID of the database to update." + commonIdDescription,
       },
       title: {
         type: "array",
@@ -727,7 +721,8 @@ const createCommentTool: Tool = {
       discussion_id: {
         type: "string",
         description:
-          "The ID of an existing discussion thread to add a comment to." + commonIdDescription,
+          "The ID of an existing discussion thread to add a comment to." +
+          commonIdDescription,
       },
       rich_text: {
         type: "array",
@@ -750,7 +745,8 @@ const retrieveCommentsTool: Tool = {
       block_id: {
         type: "string",
         description:
-          "The ID of the block or page whose comments you want to retrieve." + commonIdDescription,
+          "The ID of the block or page whose comments you want to retrieve." +
+          commonIdDescription,
       },
       start_cursor: {
         type: "string",
@@ -831,7 +827,10 @@ export class NotionClientWrapper {
     };
   }
 
-  async appendBlockChildren(block_id: string, children: Partial<BlockResponse>[]): Promise<BlockResponse> {
+  async appendBlockChildren(
+    block_id: string,
+    children: Partial<BlockResponse>[]
+  ): Promise<BlockResponse> {
     const body = { children };
 
     const response = await fetch(
@@ -893,7 +892,10 @@ export class NotionClientWrapper {
     return response.json();
   }
 
-  async updatePageProperties(page_id: string, properties: Record<string, any>): Promise<PageResponse> {
+  async updatePageProperties(
+    page_id: string,
+    properties: Record<string, any>
+  ): Promise<PageResponse> {
     const body = { properties };
 
     const response = await fetch(`${this.baseUrl}/pages/${page_id}`, {
@@ -905,7 +907,10 @@ export class NotionClientWrapper {
     return response.json();
   }
 
-  async listAllUsers(start_cursor?: string, page_size?: number): Promise<ListResponse> {
+  async listAllUsers(
+    start_cursor?: string,
+    page_size?: number
+  ): Promise<ListResponse> {
     const params = new URLSearchParams();
     if (start_cursor) params.append("start_cursor", start_cursor);
     if (page_size) params.append("page_size", page_size.toString());
@@ -1007,7 +1012,10 @@ export class NotionClientWrapper {
     return response.json();
   }
 
-  async createDatabaseItem(database_id: string, properties: Record<string, any>): Promise<PageResponse> {
+  async createDatabaseItem(
+    database_id: string,
+    properties: Record<string, any>
+  ): Promise<PageResponse> {
     const body = {
       parent: { database_id },
       properties,
@@ -1097,7 +1105,7 @@ export class NotionClientWrapper {
 }
 
 // if test environment, do not execute main()
-if (process.env.NODE_ENV !== 'test' && process.env.VITEST !== 'true') {
+if (process.env.NODE_ENV !== "test" && process.env.VITEST !== "true") {
   main().catch((error) => {
     console.error("Fatal error in main():", error);
     process.exit(1);
@@ -1266,9 +1274,7 @@ async function main() {
           case "notion_retrieve_database": {
             const args = request.params
               .arguments as unknown as RetrieveDatabaseArgs;
-            response = await notionClient.retrieveDatabase(
-              args.database_id
-            );
+            response = await notionClient.retrieveDatabase(args.database_id);
             break;
           }
 

--- a/notion/src/index.ts
+++ b/notion/src/index.ts
@@ -7,6 +7,7 @@ import {
   ListToolsRequestSchema,
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
+import { convertToMarkdown } from "./markdown/index.js";
 
 // Type definitions for tool arguments
 // Blocks
@@ -384,6 +385,7 @@ const blockObjectSchema = {
   required: ["object", "type"],
 }
 
+// TODO: If modifications are made, since the original source information is necessary, add an explanation that retrieves the raw object that has not been converted to markdown, and create a dedicated tool to convert to markdown.
 // Tool definitions
 // Blocks
 const appendBlockChildrenTool: Tool = {
@@ -1065,6 +1067,10 @@ class NotionClientWrapper {
 
     return response.json();
   }
+
+  async toMarkdown(response: any): Promise<string> {
+    return convertToMarkdown(response);
+  }
 }
 
 async function main() {
@@ -1098,6 +1104,8 @@ async function main() {
           throw new Error("No arguments provided");
         }
 
+        let response;
+
         switch (request.params.name) {
           case "notion_append_block_children": {
             const args = request.params
@@ -1107,13 +1115,11 @@ async function main() {
                 "Missing required arguments: block_id and children"
               );
             }
-            const response = await notionClient.appendBlockChildren(
+            response = await notionClient.appendBlockChildren(
               args.block_id,
               args.children
             );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            break;
           }
 
           case "notion_retrieve_block": {
@@ -1122,10 +1128,8 @@ async function main() {
             if (!args.block_id) {
               throw new Error("Missing required argument: block_id");
             }
-            const response = await notionClient.retrieveBlock(args.block_id);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            response = await notionClient.retrieveBlock(args.block_id);
+            break;
           }
 
           case "notion_retrieve_block_children": {
@@ -1134,14 +1138,12 @@ async function main() {
             if (!args.block_id) {
               throw new Error("Missing required argument: block_id");
             }
-            const response = await notionClient.retrieveBlockChildren(
+            response = await notionClient.retrieveBlockChildren(
               args.block_id,
               args.start_cursor,
               args.page_size
             );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            break;
           }
 
           case "notion_delete_block": {
@@ -1149,10 +1151,8 @@ async function main() {
             if (!args.block_id) {
               throw new Error("Missing required argument: block_id");
             }
-            const response = await notionClient.deleteBlock(args.block_id);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            response = await notionClient.deleteBlock(args.block_id);
+            break;
           }
 
           case "notion_retrieve_page": {
@@ -1161,10 +1161,8 @@ async function main() {
             if (!args.page_id) {
               throw new Error("Missing required argument: page_id");
             }
-            const response = await notionClient.retrievePage(args.page_id);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            response = await notionClient.retrievePage(args.page_id);
+            break;
           }
 
           case "notion_update_page_properties": {
@@ -1175,25 +1173,21 @@ async function main() {
                 "Missing required arguments: page_id and properties"
               );
             }
-            const response = await notionClient.updatePageProperties(
+            response = await notionClient.updatePageProperties(
               args.page_id,
               args.properties
             );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            break;
           }
 
           case "notion_list_all_users": {
             const args = request.params
               .arguments as unknown as ListAllUsersArgs;
-            const response = await notionClient.listAllUsers(
+            response = await notionClient.listAllUsers(
               args.start_cursor,
               args.page_size
             );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            break;
           }
 
           case "notion_retrieve_user": {
@@ -1202,17 +1196,13 @@ async function main() {
             if (!args.user_id) {
               throw new Error("Missing required argument: user_id");
             }
-            const response = await notionClient.retrieveUser(args.user_id);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            response = await notionClient.retrieveUser(args.user_id);
+            break;
           }
 
           case "notion_retrieve_bot_user": {
-            const response = await notionClient.retrieveBotUser();
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            response = await notionClient.retrieveBotUser();
+            break;
           }
 
           case "notion_query_database": {
@@ -1221,66 +1211,56 @@ async function main() {
             if (!args.database_id) {
               throw new Error("Missing required argument: database_id");
             }
-            const response = await notionClient.queryDatabase(
+            response = await notionClient.queryDatabase(
               args.database_id,
               args.filter,
               args.sorts,
               args.start_cursor,
               args.page_size
             );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            break;
           }
 
           case "notion_create_database": {
             const args = request.params
               .arguments as unknown as CreateDatabaseArgs;
-            const response = await notionClient.createDatabase(
+            response = await notionClient.createDatabase(
               args.parent,
               args.title,
               args.properties
             );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            break;
           }
 
           case "notion_retrieve_database": {
             const args = request.params
               .arguments as unknown as RetrieveDatabaseArgs;
-            const response = await notionClient.retrieveDatabase(
+            response = await notionClient.retrieveDatabase(
               args.database_id
             );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            break;
           }
 
           case "notion_update_database": {
             const args = request.params
               .arguments as unknown as UpdateDatabaseArgs;
-            const response = await notionClient.updateDatabase(
+            response = await notionClient.updateDatabase(
               args.database_id,
               args.title,
               args.description,
               args.properties
             );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            break;
           }
 
           case "notion_create_database_item": {
             const args = request.params
               .arguments as unknown as CreateDatabaseItemArgs;
-            const response = await notionClient.createDatabaseItem(
+            response = await notionClient.createDatabaseItem(
               args.database_id,
               args.properties
             );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            break;
           }
 
           case "notion_create_comment": {
@@ -1293,14 +1273,12 @@ async function main() {
               );
             }
 
-            const response = await notionClient.createComment(
+            response = await notionClient.createComment(
               args.parent,
               args.discussion_id,
               args.rich_text
             );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            break;
           }
 
           case "notion_retrieve_comments": {
@@ -1309,32 +1287,40 @@ async function main() {
             if (!args.block_id) {
               throw new Error("Missing required argument: block_id");
             }
-            const response = await notionClient.retrieveComments(
+            response = await notionClient.retrieveComments(
               args.block_id,
               args.start_cursor,
               args.page_size
             );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            break;
           }
 
           case "notion_search": {
             const args = request.params.arguments as unknown as SearchArgs;
-            const response = await notionClient.search(
+            response = await notionClient.search(
               args.query,
               args.filter,
               args.sort,
               args.start_cursor,
               args.page_size
             );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
+            break;
           }
 
           default:
             throw new Error(`Unknown tool: ${request.params.name}`);
+        }
+
+        // TODO: create new condition for markdown
+        if (true) {
+          const markdown = await notionClient.toMarkdown(response);
+          return {
+            content: [{ type: "text", text: markdown }],
+          };
+        } else {
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
         }
       } catch (error) {
         console.error("Error executing tool:", error);

--- a/notion/src/index.ts
+++ b/notion/src/index.ts
@@ -811,7 +811,7 @@ const searchTool: Tool = {
       },
       page_size: {
         type: "number",
-        description: "Number of results to return (max 100). Default is 5.",
+        description: "Number of results to return (max 100). ",
       },
     },
   },

--- a/notion/src/index.ts
+++ b/notion/src/index.ts
@@ -159,6 +159,8 @@ interface SearchArgs {
   format?: "json" | "markdown";
 }
 
+
+// TODO: Define Type-safe request/response handling using Zod schemas
 const commonIdDescription =
   "It should be a 32-character string (excluding hyphens) formatted as 8-4-4-4-12 with hyphens (-).";
 

--- a/notion/src/markdown/index.test.ts
+++ b/notion/src/markdown/index.test.ts
@@ -721,7 +721,6 @@ describe('convertToMarkdown', () => {
     // @ts-ignore - intentionally testing with unknown type
     const markdown = convertToMarkdown(unknownResponse);
     
-    // Check if it's formatted as JSON
     expect(markdown).toMatch(/^```json\n/); // JSON code block start
     expect(markdown).toMatch(/"object": "unknown"/); // Object type
     expect(markdown).toMatch(/"id": "unknown123"/); // ID

--- a/notion/src/markdown/index.test.ts
+++ b/notion/src/markdown/index.test.ts
@@ -1,0 +1,730 @@
+import { expect, test, describe } from 'vitest';
+import { convertToMarkdown } from './index.js';
+import { PageResponse, BlockResponse, DatabaseResponse, ListResponse } from '../types/index.js';
+
+describe('convertToMarkdown', () => {
+  test('should handle null or undefined response', () => {
+    // @ts-ignore - intentionally testing with null
+    expect(convertToMarkdown(null)).toBe('');
+    // @ts-ignore - intentionally testing with undefined
+    expect(convertToMarkdown(undefined)).toBe('');
+  });
+
+  test('should convert a page response to markdown', () => {
+    // ref: https://developers.notion.com/reference/page
+    const pageResponse: PageResponse = {
+      object: "page",
+      id: "be633bf1-dfa0-436d-b259-571129a590e5",
+      created_time: "2022-10-24T22:54:00.000Z",
+      last_edited_time: "2023-03-08T18:25:00.000Z",
+      created_by: {
+        object: "user",
+        id: "c2f20311-9e54-4d11-8c79-7398424ae41e"
+      },
+      last_edited_by: {
+        object: "user",
+        id: "9188c6a5-7381-452f-b3dc-d4865aa89bdf"
+      },
+      cover: null,
+      icon: {
+        type: "emoji",
+        emoji: "🐞"
+      },
+      parent: {
+        type: "database_id",
+        database_id: "a1d8501e-1ac1-43e9-a6bd-ea9fe6c8822b"
+      },
+      archived: true,
+      in_trash: true,
+      properties: {
+        "Due date": {
+          id: "M%3BBw",
+          type: "date",
+          date: {
+            start: "2023-02-23",
+            end: null,
+            time_zone: null
+          }
+        },
+        Status: {
+          id: "Z%3ClH",
+          type: "status",
+          status: {
+            id: "86ddb6ec-0627-47f8-800d-b65afd28be13",
+            name: "Not started",
+            color: "default"
+          }
+        },
+        Title: {
+          id: "title",
+          type: "title",
+          title: [
+            {
+              type: "text",
+              text: {
+                content: "Bug bash",
+                link: null
+              },
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: "default"
+              },
+              plain_text: "Bug bash",
+              href: null
+            }
+          ]
+        }
+      },
+      url: "https://www.notion.so/Bug-bash-be633bf1dfa0436db259571129a590e5",
+      public_url: "https://jm-testing.notion.site/p1-6df2c07bfc6b4c46815ad205d132e22d"
+    };
+
+    const markdown = convertToMarkdown(pageResponse);
+    
+    // More detailed verification
+    expect(markdown).toMatch(/^# Bug bash\n\n/); // Check if title is correctly processed
+    expect(markdown).toMatch(/## Properties\n\n/); // Check if properties section exists
+    expect(markdown).toMatch(/\| Property \| Value \|\n\|\-+\|\-+\|/); // Check if property table header is correct
+    expect(markdown).toMatch(/\| Due date \| 2023-02-23 \|/); // Check if date property is correctly displayed
+    expect(markdown).toMatch(/\| Status \| Not started \|/); // Check if status property is correctly displayed
+    expect(markdown).toMatch(/\| Title \| Bug bash \|/); // Check if title property is correctly displayed
+    expect(markdown).toMatch(/> This page contains child blocks/); // Check if note about child blocks exists
+    expect(markdown).toMatch(/> Block ID: `be633bf1-dfa0-436d-b259-571129a590e5`/); // Check if block ID is correctly displayed
+    expect(markdown).toMatch(/\[View in Notion\]\(https:\/\/www\.notion\.so\/Bug-bash-be633bf1dfa0436db259571129a590e5\)/); // Check if link to Notion is correctly displayed
+  });
+
+  test('should convert a block response to markdown', () => {
+    // ref: https://developers.notion.com/reference/block
+    const blockResponse: BlockResponse = {
+      object: "block",
+      id: "c02fc1d3-db8b-45c5-a222-27595b15aea7",
+      parent: {
+        type: "page_id",
+        page_id: "59833787-2cf9-4fdf-8782-e53db20768a5"
+      },
+      created_time: "2022-03-01T19:05:00.000Z",
+      last_edited_time: "2022-07-06T19:41:00.000Z",
+      created_by: {
+        object: "user",
+        id: "ee5f0f84-409a-440f-983a-a5315961c6e4"
+      },
+      last_edited_by: {
+        object: "user",
+        id: "ee5f0f84-409a-440f-983a-a5315961c6e4"
+      },
+      has_children: false,
+      archived: false,
+      in_trash: false,
+      type: "heading_2",
+      heading_2: {
+        rich_text: [
+          {
+            type: "text",
+            text: {
+              content: "Lacinato kale",
+              link: null
+            },
+            annotations: {
+              bold: false,
+              italic: false,
+              strikethrough: false,
+              underline: false,
+              code: false,
+              color: "green"
+            },
+            plain_text: "Lacinato kale",
+            href: null
+          }
+        ],
+        color: "default",
+        is_toggleable: false
+      }
+    };
+
+    const markdown = convertToMarkdown(blockResponse);
+    
+    // Check if it's correctly displayed as a heading 2
+    expect(markdown).toBe('## Lacinato kale');
+  });
+
+  test('should convert a database response to markdown', () => {
+    // ref: https://developers.notion.com/reference/create-a-database response 200 - Result
+    const databaseResponse: DatabaseResponse = {
+      object: "database",
+      id: "bc1211ca-e3f1-4939-ae34-5260b16f627c",
+      created_time: "2021-07-08T23:50:00.000Z",
+      last_edited_time: "2021-07-08T23:50:00.000Z",
+      icon: {
+        type: "emoji",
+        emoji: "🎉"
+      },
+      cover: {
+        type: "external",
+        external: {
+          url: "https://website.domain/images/image.png"
+        }
+      },
+      url: "https://www.notion.so/bc1211cae3f14939ae34260b16f627c",
+      title: [
+        {
+          type: "text",
+          text: {
+            content: "Grocery List",
+            link: null
+          },
+          annotations: {
+            bold: false,
+            italic: false,
+            strikethrough: false,
+            underline: false,
+            code: false,
+            color: "default"
+          },
+          plain_text: "Grocery List",
+          href: null
+        }
+      ],
+      properties: {
+        "+1": {
+          id: "Wp%3DC",
+          name: "+1",
+          type: "people",
+          people: {}
+        },
+        "In stock": {
+          id: "fk%5EY",
+          name: "In stock",
+          type: "checkbox",
+          checkbox: {}
+        },
+        "Price": {
+          id: "evWq",
+          name: "Price",
+          type: "number",
+          number: {
+            format: "dollar"
+          }
+        },
+        "Description": {
+          id: "V}lX",
+          name: "Description",
+          type: "rich_text",
+          rich_text: {}
+        },
+        "Last ordered": {
+          id: "eVnV",
+          name: "Last ordered",
+          type: "date",
+          date: {}
+        },
+        "Meals": {
+          id: "%7DWA~",
+          name: "Meals",
+          type: "relation",
+          relation: {
+            database_id: "668d797c-76fa-4934-9b05-ad288df2d136",
+            synced_property_name: "Related to Grocery List (Meals)"
+          }
+        },
+        "Number of meals": {
+          id: "Z\\Eh",
+          name: "Number of meals",
+          type: "rollup",
+          rollup: {
+            rollup_property_name: "Name",
+            relation_property_name: "Meals",
+            rollup_property_id: "title",
+            relation_property_id: "mxp^",
+            function: "count"
+          }
+        },
+        "Store availability": {
+          id: "s}Kq",
+          name: "Store availability",
+          type: "multi_select",
+          multi_select: {
+            options: [
+              {
+                id: "cb79b393-d1c1-4528-b517-c450859de766",
+                name: "Duc Loi Market",
+                color: "blue"
+              },
+              {
+                id: "58aae162-75d4-403b-a793-3bc7308e4cd2",
+                name: "Rainbow Grocery",
+                color: "gray"
+              },
+              {
+                id: "22d0f199-babc-44ff-bd80-a9eae3e3fcbf",
+                name: "Nijiya Market",
+                color: "purple"
+              },
+              {
+                id: "0d069987-ffb0-4347-bde2-8e4068003dbc",
+                name: "Gus's Community Market",
+                color: "yellow"
+              }
+            ]
+          }
+        },
+        "Photo": {
+          id: "yfiK",
+          name: "Photo",
+          type: "files",
+          files: {}
+        },
+        "Food group": {
+          id: "CM%3EH",
+          name: "Food group",
+          type: "select",
+          select: {
+            options: [
+              {
+                id: "6d4523fa-88cb-4ffd-9364-1e39d0f4e566",
+                name: "🥦Vegetable",
+                color: "green"
+              },
+              {
+                id: "268d7e75-de8f-4c4b-8b9d-de0f97021833",
+                name: "🍎Fruit",
+                color: "red"
+              },
+              {
+                id: "1b234a00-dc97-489c-b987-829264cfdfef",
+                name: "💪Protein",
+                color: "yellow"
+              }
+            ]
+          }
+        },
+        "Name": {
+          id: "title",
+          name: "Name",
+          type: "title",
+          title: {}
+        }
+      },
+      parent: {
+        type: "page_id",
+        page_id: "98ad959b-2b6a-4774-80ee-00246fb0ea9b"
+      },
+      archived: false,
+      is_inline: false
+    };
+
+    const markdown = convertToMarkdown(databaseResponse);
+    
+    // More detailed verification
+    expect(markdown).toMatch(/^# Grocery List \(Database\)\n\n/); // Check if title is correctly processed
+    expect(markdown).toMatch(/## Properties\n\n/); // Check if properties section exists
+    expect(markdown).toMatch(/\| Property Name \| Type \| Details \|\n\|\-+\|\-+\|\-+\|/); // Check if property table is correct
+    
+    // Check if each property is correctly displayed
+    expect(markdown).toMatch(/\| \\\+1 \| people \| /); // +1 property
+    expect(markdown).toMatch(/\| In stock \| checkbox \| /); // In stock property
+    expect(markdown).toMatch(/\| Price \| number \| /); // Price property
+    expect(markdown).toMatch(/\| Store availability \| multi_select \| Options: Duc Loi Market, Rainbow Grocery, Nijiya Market, Gus's Community Market \|/); // Property with options
+    expect(markdown).toMatch(/\| Food group \| select \| Options: 🥦Vegetable, 🍎Fruit, 💪Protein \|/); // Options with emoji
+    expect(markdown).toMatch(/\| Meals \| relation \| Related DB: 668d797c-76fa-4934-9b05-ad288df2d136 \|/); // Relation
+    
+    // Check if link to Notion is correctly displayed
+    expect(markdown).toMatch(/\[View in Notion\]\(https:\/\/www\.notion\.so\/bc1211cae3f14939ae34260b16f627c\)/);
+  });
+
+  test('should convert a list response to markdown', () => {
+    // ref: https://developers.notion.com/reference/post-search response 200 - Result
+    const listResponse: ListResponse = {
+      object: "list",
+      results: [
+        {
+          object: "page",
+          id: "954b67f9-3f87-41db-8874-23b92bbd31ee",
+          created_time: "2022-07-06T19:30:00.000Z",
+          last_edited_time: "2022-07-06T19:30:00.000Z",
+          created_by: {
+            object: "user",
+            id: "ee5f0f84-409a-440f-983a-a5315961c6e4"
+          },
+          last_edited_by: {
+            object: "user",
+            id: "ee5f0f84-409a-440f-983a-a5315961c6e4"
+          },
+          cover: {
+            type: "external",
+            external: {
+              url: "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg"
+            }
+          },
+          icon: {
+            type: "emoji",
+            emoji: "🥬"
+          },
+          parent: {
+            type: "database_id",
+            database_id: "d9824bdc-8445-4327-be8b-5b47500af6ce"
+          },
+          archived: false,
+          properties: {
+            "Store availability": {
+              id: "%3AUPp",
+              type: "multi_select",
+              multi_select: []
+            },
+            "Food group": {
+              id: "A%40Hk",
+              type: "select",
+              select: {
+                id: "5e8e7e8f-432e-4d8a-8166-1821e10225fc",
+                name: "🥬 Vegetable",
+                color: "pink"
+              }
+            },
+            "Price": {
+              id: "BJXS",
+              type: "number",
+              number: null
+            },
+            "Responsible Person": {
+              id: "Iowm",
+              type: "people",
+              people: []
+            },
+            "Last ordered": {
+              id: "Jsfb",
+              type: "date",
+              date: null
+            },
+            "Cost of next trip": {
+              id: "WOd%3B",
+              type: "formula",
+              formula: {
+                type: "number",
+                number: null
+              }
+            },
+            "Recipes": {
+              id: "YfIu",
+              type: "relation",
+              relation: []
+            },
+            "Description": {
+              id: "_Tc_",
+              type: "rich_text",
+              rich_text: [
+                {
+                  type: "text",
+                  text: {
+                    content: "A dark green leafy vegetable",
+                    link: null
+                  },
+                  annotations: {
+                    bold: false,
+                    italic: false,
+                    strikethrough: false,
+                    underline: false,
+                    code: false,
+                    color: "default"
+                  },
+                  plain_text: "A dark green leafy vegetable",
+                  href: null
+                }
+              ]
+            },
+            "In stock": {
+              id: "%60%5Bq%3F",
+              type: "checkbox",
+              checkbox: false
+            },
+            "Number of meals": {
+              id: "zag~",
+              type: "rollup",
+              rollup: {
+                type: "number",
+                number: 0,
+                function: "count"
+              }
+            },
+            "Photo": {
+              id: "%7DF_L",
+              type: "url",
+              url: null
+            },
+            "Name": {
+              id: "title",
+              type: "title",
+              title: [
+                {
+                  type: "text",
+                  text: {
+                    content: "Tuscan kale",
+                    link: null
+                  },
+                  annotations: {
+                    bold: false,
+                    italic: false,
+                    strikethrough: false,
+                    underline: false,
+                    code: false,
+                    color: "default"
+                  },
+                  plain_text: "Tuscan kale",
+                  href: null
+                }
+              ]
+            }
+          },
+          url: "https://www.notion.so/Tuscan-kale-954b67f93f8741db887423b92bbd31ee"
+        },
+        {
+          object: "page",
+          id: "59833787-2cf9-4fdf-8782-e53db20768a5",
+          created_time: "2022-03-01T19:05:00.000Z",
+          last_edited_time: "2022-07-06T20:25:00.000Z",
+          created_by: {
+            object: "user",
+            id: "ee5f0f84-409a-440f-983a-a5315961c6e4"
+          },
+          last_edited_by: {
+            object: "user",
+            id: "0c3e9826-b8f7-4f73-927d-2caaf86f1103"
+          },
+          cover: {
+            type: "external",
+            external: {
+              url: "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg"
+            }
+          },
+          icon: {
+            type: "emoji",
+            emoji: "🥬"
+          },
+          parent: {
+            type: "database_id",
+            database_id: "d9824bdc-8445-4327-be8b-5b47500af6ce"
+          },
+          archived: false,
+          properties: {
+            "Store availability": {
+              id: "%3AUPp",
+              type: "multi_select",
+              multi_select: [
+                {
+                  id: "t|O@",
+                  name: "Gus's Community Market",
+                  color: "yellow"
+                },
+                {
+                  id: "{Ml\\",
+                  name: "Rainbow Grocery",
+                  color: "gray"
+                }
+              ]
+            },
+            "Food group": {
+              id: "A%40Hk",
+              type: "select",
+              select: {
+                id: "5e8e7e8f-432e-4d8a-8166-1821e10225fc",
+                name: "🥬 Vegetable",
+                color: "pink"
+              }
+            },
+            "Price": {
+              id: "BJXS",
+              type: "number",
+              number: 2.5
+            },
+            "Responsible Person": {
+              id: "Iowm",
+              type: "people",
+              people: [
+                {
+                  object: "user",
+                  id: "cbfe3c6e-71cf-4cd3-b6e7-02f38f371bcc",
+                  name: "Cristina Cordova",
+                  avatar_url: "https://lh6.googleusercontent.com/-rapvfCoTq5A/AAAAAAAAAAI/AAAAAAAAAAA/AKF05nDKmmUpkpFvWNBzvu9rnZEy7cbl8Q/photo.jpg",
+                  type: "person",
+                  person: {
+                    email: "cristina@makenotion.com"
+                  }
+                }
+              ]
+            },
+            "Last ordered": {
+              id: "Jsfb",
+              type: "date",
+              date: {
+                start: "2022-02-22",
+                end: null,
+                time_zone: null
+              }
+            },
+            "Cost of next trip": {
+              id: "WOd%3B",
+              type: "formula",
+              formula: {
+                type: "number",
+                number: 0
+              }
+            },
+            "Recipes": {
+              id: "YfIu",
+              type: "relation",
+              relation: [
+                {
+                  id: "90eeeed8-2cdd-4af4-9cc1-3d24aff5f63c"
+                },
+                {
+                  id: "a2da43ee-d43c-4285-8ae2-6d811f12629a"
+                }
+              ],
+              has_more: false
+            },
+            "Description": {
+              id: "_Tc_",
+              type: "rich_text",
+              rich_text: [
+                {
+                  type: "text",
+                  text: {
+                    content: "A dark ",
+                    link: null
+                  },
+                  annotations: {
+                    bold: false,
+                    italic: false,
+                    strikethrough: false,
+                    underline: false,
+                    code: false,
+                    color: "default"
+                  },
+                  plain_text: "A dark ",
+                  href: null
+                },
+                {
+                  type: "text",
+                  text: {
+                    content: "green",
+                    link: null
+                  },
+                  annotations: {
+                    bold: false,
+                    italic: false,
+                    strikethrough: false,
+                    underline: false,
+                    code: false,
+                    color: "green"
+                  },
+                  plain_text: "green",
+                  href: null
+                },
+                {
+                  type: "text",
+                  text: {
+                    content: " leafy vegetable",
+                    link: null
+                  },
+                  annotations: {
+                    bold: false,
+                    italic: false,
+                    strikethrough: false,
+                    underline: false,
+                    code: false,
+                    color: "default"
+                  },
+                  plain_text: " leafy vegetable",
+                  href: null
+                }
+              ]
+            },
+            "In stock": {
+              id: "%60%5Bq%3F",
+              type: "checkbox",
+              checkbox: true
+            },
+            "Number of meals": {
+              id: "zag~",
+              type: "rollup",
+              rollup: {
+                type: "number",
+                number: 2,
+                function: "count"
+              }
+            },
+            "Photo": {
+              id: "%7DF_L",
+              type: "url",
+              url: "https://i.insider.com/612fb23c9ef1e50018f93198?width=1136&format=jpeg"
+            },
+            "Name": {
+              id: "title",
+              type: "title",
+              title: [
+                {
+                  type: "text",
+                  text: {
+                    content: "Tuscan kale",
+                    link: null
+                  },
+                  annotations: {
+                    bold: false,
+                    italic: false,
+                    strikethrough: false,
+                    underline: false,
+                    code: false,
+                    color: "default"
+                  },
+                  plain_text: "Tuscan kale",
+                  href: null
+                }
+              ]
+            }
+          },
+          url: "https://www.notion.so/Tuscan-kale-598337872cf94fdf8782e53db20768a5"
+        }
+      ],
+      next_cursor: null,
+      has_more: false,
+      type: "page_or_database",
+      page_or_database: {}
+    };
+
+    const markdown = convertToMarkdown(listResponse);
+    
+    // More detailed verification
+    expect(markdown).toMatch(/^# Search Results \(Pages\)\n\n/); // Check if header is correct
+    
+    // Check if title and link for each page in the search results are included
+    expect(markdown).toMatch(/## \[Tuscan kale\]\(https:\/\/www\.notion\.so\/Tuscan-kale-954b67f93f8741db887423b92bbd31ee\)/); // First page
+    expect(markdown).toMatch(/ID: `954b67f9-3f87-41db-8874-23b92bbd31ee`/); // First page ID
+    
+    expect(markdown).toMatch(/## \[Tuscan kale\]\(https:\/\/www\.notion\.so\/Tuscan-kale-598337872cf94fdf8782e53db20768a5\)/); // Second page
+    expect(markdown).toMatch(/ID: `59833787-2cf9-4fdf-8782-e53db20768a5`/); // Second page ID
+    
+    // Check if each result is separated by a divider line
+    expect(markdown).toMatch(/---\n\n/);
+    
+    // Check that pagination info is not present (because has_more is false)
+    expect(markdown).not.toMatch(/More results available/);
+  });
+
+  test('should convert unknown object type to JSON', () => {
+    const unknownResponse = {
+      object: 'unknown',
+      id: 'unknown123'
+    };
+
+    // @ts-ignore - intentionally testing with unknown type
+    const markdown = convertToMarkdown(unknownResponse);
+    
+    // Check if it's formatted as JSON
+    expect(markdown).toMatch(/^```json\n/); // JSON code block start
+    expect(markdown).toMatch(/"object": "unknown"/); // Object type
+    expect(markdown).toMatch(/"id": "unknown123"/); // ID
+    expect(markdown).toMatch(/\n```$/); // JSON code block end
+  });
+}); 

--- a/notion/src/markdown/index.test.ts
+++ b/notion/src/markdown/index.test.ts
@@ -1,16 +1,21 @@
-import { expect, test, describe } from 'vitest';
-import { convertToMarkdown } from './index.js';
-import { PageResponse, BlockResponse, DatabaseResponse, ListResponse } from '../types/index.js';
+import { expect, test, describe } from "vitest";
+import { convertToMarkdown } from "./index.js";
+import {
+  PageResponse,
+  BlockResponse,
+  DatabaseResponse,
+  ListResponse,
+} from "../types/index.js";
 
-describe('convertToMarkdown', () => {
-  test('should handle null or undefined response', () => {
+describe("convertToMarkdown", () => {
+  test("should handle null or undefined response", () => {
     // @ts-ignore - intentionally testing with null
-    expect(convertToMarkdown(null)).toBe('');
+    expect(convertToMarkdown(null)).toBe("");
     // @ts-ignore - intentionally testing with undefined
-    expect(convertToMarkdown(undefined)).toBe('');
+    expect(convertToMarkdown(undefined)).toBe("");
   });
 
-  test('should convert a page response to markdown', () => {
+  test("should convert a page response to markdown", () => {
     // ref: https://developers.notion.com/reference/page
     const pageResponse: PageResponse = {
       object: "page",
@@ -19,20 +24,20 @@ describe('convertToMarkdown', () => {
       last_edited_time: "2023-03-08T18:25:00.000Z",
       created_by: {
         object: "user",
-        id: "c2f20311-9e54-4d11-8c79-7398424ae41e"
+        id: "c2f20311-9e54-4d11-8c79-7398424ae41e",
       },
       last_edited_by: {
         object: "user",
-        id: "9188c6a5-7381-452f-b3dc-d4865aa89bdf"
+        id: "9188c6a5-7381-452f-b3dc-d4865aa89bdf",
       },
       cover: null,
       icon: {
         type: "emoji",
-        emoji: "🐞"
+        emoji: "🐞",
       },
       parent: {
         type: "database_id",
-        database_id: "a1d8501e-1ac1-43e9-a6bd-ea9fe6c8822b"
+        database_id: "a1d8501e-1ac1-43e9-a6bd-ea9fe6c8822b",
       },
       archived: true,
       in_trash: true,
@@ -43,8 +48,8 @@ describe('convertToMarkdown', () => {
           date: {
             start: "2023-02-23",
             end: null,
-            time_zone: null
-          }
+            time_zone: null,
+          },
         },
         Status: {
           id: "Z%3ClH",
@@ -52,8 +57,8 @@ describe('convertToMarkdown', () => {
           status: {
             id: "86ddb6ec-0627-47f8-800d-b65afd28be13",
             name: "Not started",
-            color: "default"
-          }
+            color: "default",
+          },
         },
         Title: {
           id: "title",
@@ -63,7 +68,7 @@ describe('convertToMarkdown', () => {
               type: "text",
               text: {
                 content: "Bug bash",
-                link: null
+                link: null,
               },
               annotations: {
                 bold: false,
@@ -71,20 +76,21 @@ describe('convertToMarkdown', () => {
                 strikethrough: false,
                 underline: false,
                 code: false,
-                color: "default"
+                color: "default",
               },
               plain_text: "Bug bash",
-              href: null
-            }
-          ]
-        }
+              href: null,
+            },
+          ],
+        },
       },
       url: "https://www.notion.so/Bug-bash-be633bf1dfa0436db259571129a590e5",
-      public_url: "https://jm-testing.notion.site/p1-6df2c07bfc6b4c46815ad205d132e22d"
+      public_url:
+        "https://jm-testing.notion.site/p1-6df2c07bfc6b4c46815ad205d132e22d",
     };
 
     const markdown = convertToMarkdown(pageResponse);
-    
+
     // More detailed verification
     expect(markdown).toMatch(/^# Bug bash\n\n/); // Check if title is correctly processed
     expect(markdown).toMatch(/## Properties\n\n/); // Check if properties section exists
@@ -93,28 +99,32 @@ describe('convertToMarkdown', () => {
     expect(markdown).toMatch(/\| Status \| Not started \|/); // Check if status property is correctly displayed
     expect(markdown).toMatch(/\| Title \| Bug bash \|/); // Check if title property is correctly displayed
     expect(markdown).toMatch(/> This page contains child blocks/); // Check if note about child blocks exists
-    expect(markdown).toMatch(/> Block ID: `be633bf1-dfa0-436d-b259-571129a590e5`/); // Check if block ID is correctly displayed
-    expect(markdown).toMatch(/\[View in Notion\]\(https:\/\/www\.notion\.so\/Bug-bash-be633bf1dfa0436db259571129a590e5\)/); // Check if link to Notion is correctly displayed
+    expect(markdown).toMatch(
+      /> Block ID: `be633bf1-dfa0-436d-b259-571129a590e5`/
+    ); // Check if block ID is correctly displayed
+    expect(markdown).toMatch(
+      /\[View in Notion\]\(https:\/\/www\.notion\.so\/Bug-bash-be633bf1dfa0436db259571129a590e5\)/
+    ); // Check if link to Notion is correctly displayed
   });
 
-  test('should convert a block response to markdown', () => {
+  test("should convert a block response to markdown", () => {
     // ref: https://developers.notion.com/reference/block
     const blockResponse: BlockResponse = {
       object: "block",
       id: "c02fc1d3-db8b-45c5-a222-27595b15aea7",
       parent: {
         type: "page_id",
-        page_id: "59833787-2cf9-4fdf-8782-e53db20768a5"
+        page_id: "59833787-2cf9-4fdf-8782-e53db20768a5",
       },
       created_time: "2022-03-01T19:05:00.000Z",
       last_edited_time: "2022-07-06T19:41:00.000Z",
       created_by: {
         object: "user",
-        id: "ee5f0f84-409a-440f-983a-a5315961c6e4"
+        id: "ee5f0f84-409a-440f-983a-a5315961c6e4",
       },
       last_edited_by: {
         object: "user",
-        id: "ee5f0f84-409a-440f-983a-a5315961c6e4"
+        id: "ee5f0f84-409a-440f-983a-a5315961c6e4",
       },
       has_children: false,
       archived: false,
@@ -126,7 +136,7 @@ describe('convertToMarkdown', () => {
             type: "text",
             text: {
               content: "Lacinato kale",
-              link: null
+              link: null,
             },
             annotations: {
               bold: false,
@@ -134,24 +144,24 @@ describe('convertToMarkdown', () => {
               strikethrough: false,
               underline: false,
               code: false,
-              color: "green"
+              color: "green",
             },
             plain_text: "Lacinato kale",
-            href: null
-          }
+            href: null,
+          },
         ],
         color: "default",
-        is_toggleable: false
-      }
+        is_toggleable: false,
+      },
     };
 
     const markdown = convertToMarkdown(blockResponse);
-    
+
     // Check if it's correctly displayed as a heading 2
-    expect(markdown).toBe('## Lacinato kale');
+    expect(markdown).toBe("## Lacinato kale");
   });
 
-  test('should convert a database response to markdown', () => {
+  test("should convert a database response to markdown", () => {
     // ref: https://developers.notion.com/reference/create-a-database response 200 - Result
     const databaseResponse: DatabaseResponse = {
       object: "database",
@@ -160,13 +170,13 @@ describe('convertToMarkdown', () => {
       last_edited_time: "2021-07-08T23:50:00.000Z",
       icon: {
         type: "emoji",
-        emoji: "🎉"
+        emoji: "🎉",
       },
       cover: {
         type: "external",
         external: {
-          url: "https://website.domain/images/image.png"
-        }
+          url: "https://website.domain/images/image.png",
+        },
       },
       url: "https://www.notion.so/bc1211cae3f14939ae34260b16f627c",
       title: [
@@ -174,7 +184,7 @@ describe('convertToMarkdown', () => {
           type: "text",
           text: {
             content: "Grocery List",
-            link: null
+            link: null,
           },
           annotations: {
             bold: false,
@@ -182,53 +192,53 @@ describe('convertToMarkdown', () => {
             strikethrough: false,
             underline: false,
             code: false,
-            color: "default"
+            color: "default",
           },
           plain_text: "Grocery List",
-          href: null
-        }
+          href: null,
+        },
       ],
       properties: {
         "+1": {
           id: "Wp%3DC",
           name: "+1",
           type: "people",
-          people: {}
+          people: {},
         },
         "In stock": {
           id: "fk%5EY",
           name: "In stock",
           type: "checkbox",
-          checkbox: {}
+          checkbox: {},
         },
-        "Price": {
+        Price: {
           id: "evWq",
           name: "Price",
           type: "number",
           number: {
-            format: "dollar"
-          }
+            format: "dollar",
+          },
         },
-        "Description": {
+        Description: {
           id: "V}lX",
           name: "Description",
           type: "rich_text",
-          rich_text: {}
+          rich_text: {},
         },
         "Last ordered": {
           id: "eVnV",
           name: "Last ordered",
           type: "date",
-          date: {}
+          date: {},
         },
-        "Meals": {
+        Meals: {
           id: "%7DWA~",
           name: "Meals",
           type: "relation",
           relation: {
             database_id: "668d797c-76fa-4934-9b05-ad288df2d136",
-            synced_property_name: "Related to Grocery List (Meals)"
-          }
+            synced_property_name: "Related to Grocery List (Meals)",
+          },
         },
         "Number of meals": {
           id: "Z\\Eh",
@@ -239,8 +249,8 @@ describe('convertToMarkdown', () => {
             relation_property_name: "Meals",
             rollup_property_id: "title",
             relation_property_id: "mxp^",
-            function: "count"
-          }
+            function: "count",
+          },
         },
         "Store availability": {
           id: "s}Kq",
@@ -251,31 +261,31 @@ describe('convertToMarkdown', () => {
               {
                 id: "cb79b393-d1c1-4528-b517-c450859de766",
                 name: "Duc Loi Market",
-                color: "blue"
+                color: "blue",
               },
               {
                 id: "58aae162-75d4-403b-a793-3bc7308e4cd2",
                 name: "Rainbow Grocery",
-                color: "gray"
+                color: "gray",
               },
               {
                 id: "22d0f199-babc-44ff-bd80-a9eae3e3fcbf",
                 name: "Nijiya Market",
-                color: "purple"
+                color: "purple",
               },
               {
                 id: "0d069987-ffb0-4347-bde2-8e4068003dbc",
                 name: "Gus's Community Market",
-                color: "yellow"
-              }
-            ]
-          }
+                color: "yellow",
+              },
+            ],
+          },
         },
-        "Photo": {
+        Photo: {
           id: "yfiK",
           name: "Photo",
           type: "files",
-          files: {}
+          files: {},
         },
         "Food group": {
           id: "CM%3EH",
@@ -286,56 +296,66 @@ describe('convertToMarkdown', () => {
               {
                 id: "6d4523fa-88cb-4ffd-9364-1e39d0f4e566",
                 name: "🥦Vegetable",
-                color: "green"
+                color: "green",
               },
               {
                 id: "268d7e75-de8f-4c4b-8b9d-de0f97021833",
                 name: "🍎Fruit",
-                color: "red"
+                color: "red",
               },
               {
                 id: "1b234a00-dc97-489c-b987-829264cfdfef",
                 name: "💪Protein",
-                color: "yellow"
-              }
-            ]
-          }
+                color: "yellow",
+              },
+            ],
+          },
         },
-        "Name": {
+        Name: {
           id: "title",
           name: "Name",
           type: "title",
-          title: {}
-        }
+          title: {},
+        },
       },
       parent: {
         type: "page_id",
-        page_id: "98ad959b-2b6a-4774-80ee-00246fb0ea9b"
+        page_id: "98ad959b-2b6a-4774-80ee-00246fb0ea9b",
       },
       archived: false,
-      is_inline: false
+      is_inline: false,
     };
 
     const markdown = convertToMarkdown(databaseResponse);
-    
+
     // More detailed verification
     expect(markdown).toMatch(/^# Grocery List \(Database\)\n\n/); // Check if title is correctly processed
     expect(markdown).toMatch(/## Properties\n\n/); // Check if properties section exists
-    expect(markdown).toMatch(/\| Property Name \| Type \| Details \|\n\|\-+\|\-+\|\-+\|/); // Check if property table is correct
-    
+    expect(markdown).toMatch(
+      /\| Property Name \| Type \| Details \|\n\|\-+\|\-+\|\-+\|/
+    ); // Check if property table is correct
+
     // Check if each property is correctly displayed
     expect(markdown).toMatch(/\| \\\+1 \| people \| /); // +1 property
     expect(markdown).toMatch(/\| In stock \| checkbox \| /); // In stock property
     expect(markdown).toMatch(/\| Price \| number \| /); // Price property
-    expect(markdown).toMatch(/\| Store availability \| multi_select \| Options: Duc Loi Market, Rainbow Grocery, Nijiya Market, Gus's Community Market \|/); // Property with options
-    expect(markdown).toMatch(/\| Food group \| select \| Options: 🥦Vegetable, 🍎Fruit, 💪Protein \|/); // Options with emoji
-    expect(markdown).toMatch(/\| Meals \| relation \| Related DB: 668d797c-76fa-4934-9b05-ad288df2d136 \|/); // Relation
-    
+    expect(markdown).toMatch(
+      /\| Store availability \| multi_select \| Options: Duc Loi Market, Rainbow Grocery, Nijiya Market, Gus's Community Market \|/
+    ); // Property with options
+    expect(markdown).toMatch(
+      /\| Food group \| select \| Options: 🥦Vegetable, 🍎Fruit, 💪Protein \|/
+    ); // Options with emoji
+    expect(markdown).toMatch(
+      /\| Meals \| relation \| Related DB: 668d797c-76fa-4934-9b05-ad288df2d136 \|/
+    ); // Relation
+
     // Check if link to Notion is correctly displayed
-    expect(markdown).toMatch(/\[View in Notion\]\(https:\/\/www\.notion\.so\/bc1211cae3f14939ae34260b16f627c\)/);
+    expect(markdown).toMatch(
+      /\[View in Notion\]\(https:\/\/www\.notion\.so\/bc1211cae3f14939ae34260b16f627c\)/
+    );
   });
 
-  test('should convert a list response to markdown', () => {
+  test("should convert a list response to markdown", () => {
     // ref: https://developers.notion.com/reference/post-search response 200 - Result
     const listResponse: ListResponse = {
       object: "list",
@@ -347,32 +367,32 @@ describe('convertToMarkdown', () => {
           last_edited_time: "2022-07-06T19:30:00.000Z",
           created_by: {
             object: "user",
-            id: "ee5f0f84-409a-440f-983a-a5315961c6e4"
+            id: "ee5f0f84-409a-440f-983a-a5315961c6e4",
           },
           last_edited_by: {
             object: "user",
-            id: "ee5f0f84-409a-440f-983a-a5315961c6e4"
+            id: "ee5f0f84-409a-440f-983a-a5315961c6e4",
           },
           cover: {
             type: "external",
             external: {
-              url: "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg"
-            }
+              url: "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg",
+            },
           },
           icon: {
             type: "emoji",
-            emoji: "🥬"
+            emoji: "🥬",
           },
           parent: {
             type: "database_id",
-            database_id: "d9824bdc-8445-4327-be8b-5b47500af6ce"
+            database_id: "d9824bdc-8445-4327-be8b-5b47500af6ce",
           },
           archived: false,
           properties: {
             "Store availability": {
               id: "%3AUPp",
               type: "multi_select",
-              multi_select: []
+              multi_select: [],
             },
             "Food group": {
               id: "A%40Hk",
@@ -380,38 +400,38 @@ describe('convertToMarkdown', () => {
               select: {
                 id: "5e8e7e8f-432e-4d8a-8166-1821e10225fc",
                 name: "🥬 Vegetable",
-                color: "pink"
-              }
+                color: "pink",
+              },
             },
-            "Price": {
+            Price: {
               id: "BJXS",
               type: "number",
-              number: null
+              number: null,
             },
             "Responsible Person": {
               id: "Iowm",
               type: "people",
-              people: []
+              people: [],
             },
             "Last ordered": {
               id: "Jsfb",
               type: "date",
-              date: null
+              date: null,
             },
             "Cost of next trip": {
               id: "WOd%3B",
               type: "formula",
               formula: {
                 type: "number",
-                number: null
-              }
+                number: null,
+              },
             },
-            "Recipes": {
+            Recipes: {
               id: "YfIu",
               type: "relation",
-              relation: []
+              relation: [],
             },
-            "Description": {
+            Description: {
               id: "_Tc_",
               type: "rich_text",
               rich_text: [
@@ -419,7 +439,7 @@ describe('convertToMarkdown', () => {
                   type: "text",
                   text: {
                     content: "A dark green leafy vegetable",
-                    link: null
+                    link: null,
                   },
                   annotations: {
                     bold: false,
@@ -427,17 +447,17 @@ describe('convertToMarkdown', () => {
                     strikethrough: false,
                     underline: false,
                     code: false,
-                    color: "default"
+                    color: "default",
                   },
                   plain_text: "A dark green leafy vegetable",
-                  href: null
-                }
-              ]
+                  href: null,
+                },
+              ],
             },
             "In stock": {
               id: "%60%5Bq%3F",
               type: "checkbox",
-              checkbox: false
+              checkbox: false,
             },
             "Number of meals": {
               id: "zag~",
@@ -445,15 +465,15 @@ describe('convertToMarkdown', () => {
               rollup: {
                 type: "number",
                 number: 0,
-                function: "count"
-              }
+                function: "count",
+              },
             },
-            "Photo": {
+            Photo: {
               id: "%7DF_L",
               type: "url",
-              url: null
+              url: null,
             },
-            "Name": {
+            Name: {
               id: "title",
               type: "title",
               title: [
@@ -461,7 +481,7 @@ describe('convertToMarkdown', () => {
                   type: "text",
                   text: {
                     content: "Tuscan kale",
-                    link: null
+                    link: null,
                   },
                   annotations: {
                     bold: false,
@@ -469,15 +489,15 @@ describe('convertToMarkdown', () => {
                     strikethrough: false,
                     underline: false,
                     code: false,
-                    color: "default"
+                    color: "default",
                   },
                   plain_text: "Tuscan kale",
-                  href: null
-                }
-              ]
-            }
+                  href: null,
+                },
+              ],
+            },
           },
-          url: "https://www.notion.so/Tuscan-kale-954b67f93f8741db887423b92bbd31ee"
+          url: "https://www.notion.so/Tuscan-kale-954b67f93f8741db887423b92bbd31ee",
         },
         {
           object: "page",
@@ -486,25 +506,25 @@ describe('convertToMarkdown', () => {
           last_edited_time: "2022-07-06T20:25:00.000Z",
           created_by: {
             object: "user",
-            id: "ee5f0f84-409a-440f-983a-a5315961c6e4"
+            id: "ee5f0f84-409a-440f-983a-a5315961c6e4",
           },
           last_edited_by: {
             object: "user",
-            id: "0c3e9826-b8f7-4f73-927d-2caaf86f1103"
+            id: "0c3e9826-b8f7-4f73-927d-2caaf86f1103",
           },
           cover: {
             type: "external",
             external: {
-              url: "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg"
-            }
+              url: "https://upload.wikimedia.org/wikipedia/commons/6/62/Tuscankale.jpg",
+            },
           },
           icon: {
             type: "emoji",
-            emoji: "🥬"
+            emoji: "🥬",
           },
           parent: {
             type: "database_id",
-            database_id: "d9824bdc-8445-4327-be8b-5b47500af6ce"
+            database_id: "d9824bdc-8445-4327-be8b-5b47500af6ce",
           },
           archived: false,
           properties: {
@@ -515,14 +535,14 @@ describe('convertToMarkdown', () => {
                 {
                   id: "t|O@",
                   name: "Gus's Community Market",
-                  color: "yellow"
+                  color: "yellow",
                 },
                 {
                   id: "{Ml\\",
                   name: "Rainbow Grocery",
-                  color: "gray"
-                }
-              ]
+                  color: "gray",
+                },
+              ],
             },
             "Food group": {
               id: "A%40Hk",
@@ -530,13 +550,13 @@ describe('convertToMarkdown', () => {
               select: {
                 id: "5e8e7e8f-432e-4d8a-8166-1821e10225fc",
                 name: "🥬 Vegetable",
-                color: "pink"
-              }
+                color: "pink",
+              },
             },
-            "Price": {
+            Price: {
               id: "BJXS",
               type: "number",
-              number: 2.5
+              number: 2.5,
             },
             "Responsible Person": {
               id: "Iowm",
@@ -546,13 +566,14 @@ describe('convertToMarkdown', () => {
                   object: "user",
                   id: "cbfe3c6e-71cf-4cd3-b6e7-02f38f371bcc",
                   name: "Cristina Cordova",
-                  avatar_url: "https://lh6.googleusercontent.com/-rapvfCoTq5A/AAAAAAAAAAI/AAAAAAAAAAA/AKF05nDKmmUpkpFvWNBzvu9rnZEy7cbl8Q/photo.jpg",
+                  avatar_url:
+                    "https://lh6.googleusercontent.com/-rapvfCoTq5A/AAAAAAAAAAI/AAAAAAAAAAA/AKF05nDKmmUpkpFvWNBzvu9rnZEy7cbl8Q/photo.jpg",
                   type: "person",
                   person: {
-                    email: "cristina@makenotion.com"
-                  }
-                }
-              ]
+                    email: "cristina@makenotion.com",
+                  },
+                },
+              ],
             },
             "Last ordered": {
               id: "Jsfb",
@@ -560,31 +581,31 @@ describe('convertToMarkdown', () => {
               date: {
                 start: "2022-02-22",
                 end: null,
-                time_zone: null
-              }
+                time_zone: null,
+              },
             },
             "Cost of next trip": {
               id: "WOd%3B",
               type: "formula",
               formula: {
                 type: "number",
-                number: 0
-              }
+                number: 0,
+              },
             },
-            "Recipes": {
+            Recipes: {
               id: "YfIu",
               type: "relation",
               relation: [
                 {
-                  id: "90eeeed8-2cdd-4af4-9cc1-3d24aff5f63c"
+                  id: "90eeeed8-2cdd-4af4-9cc1-3d24aff5f63c",
                 },
                 {
-                  id: "a2da43ee-d43c-4285-8ae2-6d811f12629a"
-                }
+                  id: "a2da43ee-d43c-4285-8ae2-6d811f12629a",
+                },
               ],
-              has_more: false
+              has_more: false,
             },
-            "Description": {
+            Description: {
               id: "_Tc_",
               type: "rich_text",
               rich_text: [
@@ -592,7 +613,7 @@ describe('convertToMarkdown', () => {
                   type: "text",
                   text: {
                     content: "A dark ",
-                    link: null
+                    link: null,
                   },
                   annotations: {
                     bold: false,
@@ -600,16 +621,16 @@ describe('convertToMarkdown', () => {
                     strikethrough: false,
                     underline: false,
                     code: false,
-                    color: "default"
+                    color: "default",
                   },
                   plain_text: "A dark ",
-                  href: null
+                  href: null,
                 },
                 {
                   type: "text",
                   text: {
                     content: "green",
-                    link: null
+                    link: null,
                   },
                   annotations: {
                     bold: false,
@@ -617,16 +638,16 @@ describe('convertToMarkdown', () => {
                     strikethrough: false,
                     underline: false,
                     code: false,
-                    color: "green"
+                    color: "green",
                   },
                   plain_text: "green",
-                  href: null
+                  href: null,
                 },
                 {
                   type: "text",
                   text: {
                     content: " leafy vegetable",
-                    link: null
+                    link: null,
                   },
                   annotations: {
                     bold: false,
@@ -634,17 +655,17 @@ describe('convertToMarkdown', () => {
                     strikethrough: false,
                     underline: false,
                     code: false,
-                    color: "default"
+                    color: "default",
                   },
                   plain_text: " leafy vegetable",
-                  href: null
-                }
-              ]
+                  href: null,
+                },
+              ],
             },
             "In stock": {
               id: "%60%5Bq%3F",
               type: "checkbox",
-              checkbox: true
+              checkbox: true,
             },
             "Number of meals": {
               id: "zag~",
@@ -652,15 +673,15 @@ describe('convertToMarkdown', () => {
               rollup: {
                 type: "number",
                 number: 2,
-                function: "count"
-              }
+                function: "count",
+              },
             },
-            "Photo": {
+            Photo: {
               id: "%7DF_L",
               type: "url",
-              url: "https://i.insider.com/612fb23c9ef1e50018f93198?width=1136&format=jpeg"
+              url: "https://i.insider.com/612fb23c9ef1e50018f93198?width=1136&format=jpeg",
             },
-            "Name": {
+            Name: {
               id: "title",
               type: "title",
               title: [
@@ -668,7 +689,7 @@ describe('convertToMarkdown', () => {
                   type: "text",
                   text: {
                     content: "Tuscan kale",
-                    link: null
+                    link: null,
                   },
                   annotations: {
                     bold: false,
@@ -676,54 +697,58 @@ describe('convertToMarkdown', () => {
                     strikethrough: false,
                     underline: false,
                     code: false,
-                    color: "default"
+                    color: "default",
                   },
                   plain_text: "Tuscan kale",
-                  href: null
-                }
-              ]
-            }
+                  href: null,
+                },
+              ],
+            },
           },
-          url: "https://www.notion.so/Tuscan-kale-598337872cf94fdf8782e53db20768a5"
-        }
+          url: "https://www.notion.so/Tuscan-kale-598337872cf94fdf8782e53db20768a5",
+        },
       ],
       next_cursor: null,
       has_more: false,
       type: "page_or_database",
-      page_or_database: {}
+      page_or_database: {},
     };
 
     const markdown = convertToMarkdown(listResponse);
-    
+
     // More detailed verification
     expect(markdown).toMatch(/^# Search Results \(Pages\)\n\n/); // Check if header is correct
-    
+
     // Check if title and link for each page in the search results are included
-    expect(markdown).toMatch(/## \[Tuscan kale\]\(https:\/\/www\.notion\.so\/Tuscan-kale-954b67f93f8741db887423b92bbd31ee\)/); // First page
+    expect(markdown).toMatch(
+      /## \[Tuscan kale\]\(https:\/\/www\.notion\.so\/Tuscan-kale-954b67f93f8741db887423b92bbd31ee\)/
+    ); // First page
     expect(markdown).toMatch(/ID: `954b67f9-3f87-41db-8874-23b92bbd31ee`/); // First page ID
-    
-    expect(markdown).toMatch(/## \[Tuscan kale\]\(https:\/\/www\.notion\.so\/Tuscan-kale-598337872cf94fdf8782e53db20768a5\)/); // Second page
+
+    expect(markdown).toMatch(
+      /## \[Tuscan kale\]\(https:\/\/www\.notion\.so\/Tuscan-kale-598337872cf94fdf8782e53db20768a5\)/
+    ); // Second page
     expect(markdown).toMatch(/ID: `59833787-2cf9-4fdf-8782-e53db20768a5`/); // Second page ID
-    
+
     // Check if each result is separated by a divider line
     expect(markdown).toMatch(/---\n\n/);
-    
+
     // Check that pagination info is not present (because has_more is false)
     expect(markdown).not.toMatch(/More results available/);
   });
 
-  test('should convert unknown object type to JSON', () => {
+  test("should convert unknown object type to JSON", () => {
     const unknownResponse = {
-      object: 'unknown',
-      id: 'unknown123'
+      object: "unknown",
+      id: "unknown123",
     };
 
     // @ts-ignore - intentionally testing with unknown type
     const markdown = convertToMarkdown(unknownResponse);
-    
+
     expect(markdown).toMatch(/^```json\n/); // JSON code block start
     expect(markdown).toMatch(/"object": "unknown"/); // Object type
     expect(markdown).toMatch(/"id": "unknown123"/); // ID
     expect(markdown).toMatch(/\n```$/); // JSON code block end
   });
-}); 
+});

--- a/notion/src/markdown/index.ts
+++ b/notion/src/markdown/index.ts
@@ -1,0 +1,431 @@
+/**
+ * Utilities for converting Notion API responses to Markdown
+ */
+
+/**
+ * Converts Notion API response to Markdown
+ * @param response Response from Notion API
+ * @returns Markdown formatted string
+ */
+export function convertToMarkdown(response: any): string {
+  // Execute appropriate conversion process based on response type
+  if (!response) return '';
+  
+  // Branch processing by object type
+  switch (response.object) {
+    case 'page':
+      return convertPageToMarkdown(response);
+    case 'database':
+      return convertDatabaseToMarkdown(response);
+    case 'block':
+      return convertBlockToMarkdown(response);
+    case 'list':
+      return convertListToMarkdown(response);
+    default:
+      // Return JSON string if conversion is not possible
+      return `\`\`\`json\n${JSON.stringify(response, null, 2)}\n\`\`\``;
+  }
+}
+
+/**
+ * Converts a Notion page to Markdown
+ */
+function convertPageToMarkdown(page: any): string {
+  let markdown = '';
+
+  // Extract title (from properties)
+  const title = extractPageTitle(page);
+  if (title) {
+    markdown += `# ${title}\n\n`;
+  }
+
+  // Display page properties as a Markdown table
+  markdown += convertPropertiesToMarkdown(page.properties);
+
+  // Include additional information if there are child blocks
+  markdown += '\n\n> This page contains child blocks. You can retrieve them using `retrieveBlockChildren`.\n';
+  markdown += `> Block ID: \`${page.id}\`\n`;
+
+  // Include page URL if available
+  if (page.url) {
+    markdown += `\n[View in Notion](${page.url})\n`;
+  }
+
+  return markdown;
+}
+
+/**
+ * Converts a Notion database to Markdown
+ */
+function convertDatabaseToMarkdown(database: any): string {
+  let markdown = '';
+
+  // Extract database title
+  const title = extractRichText(database.title || []);
+  if (title) {
+    markdown += `# ${title} (Database)\n\n`;
+  }
+
+  // Add description if available
+  const description = extractRichText(database.description || []);
+  if (description) {
+    markdown += `${description}\n\n`;
+  }
+
+  // Display database property schema
+  if (database.properties) {
+    markdown += '## Properties\n\n';
+    markdown += '| Property Name | Type | Details |\n';
+    markdown += '|------------|------|------|\n';
+
+    Object.entries(database.properties).forEach(([key, prop]: [string, any]) => {
+      const propName = prop.name || key;
+      const propType = prop.type || 'unknown';
+      
+      // Additional information based on property type
+      let details = '';
+      switch (propType) {
+        case 'select':
+        case 'multi_select':
+          const options = prop[propType]?.options || [];
+          details = `Options: ${options.map((o: any) => o.name).join(', ')}`;
+          break;
+        case 'relation':
+          details = `Related DB: ${prop.relation.database_id || ''}`;
+          break;
+        case 'formula':
+          details = `Formula: ${prop.formula.expression || ''}`;
+          break;
+        // Add other property types as needed
+      }
+      
+      markdown += `| ${escapeTableCell(propName)} | ${propType} | ${escapeTableCell(details)} |\n`;
+    });
+    
+    markdown += '\n';
+  }
+
+  // Include database URL if available
+  if (database.url) {
+    markdown += `\n[View in Notion](${database.url})\n`;
+  }
+
+  return markdown;
+}
+
+/**
+ * Converts Notion API block response to Markdown
+ */
+function convertBlockToMarkdown(block: any): string {
+  if (!block) return '';
+
+  // Convert based on block type
+  return renderBlock(block);
+}
+
+/**
+ * Converts list response (search results or block children) to Markdown
+ */
+function convertListToMarkdown(list: any): string {
+  if (!list || !list.results || !Array.isArray(list.results)) {
+    return '```\nNo results\n```';
+  }
+
+  let markdown = '';
+  
+  // Determine the type of results
+  const firstResult = list.results[0];
+  const resultType = firstResult?.object || 'unknown';
+  
+  // Add header based on type
+  switch (resultType) {
+    case 'page':
+      markdown += '# Search Results (Pages)\n\n';
+      break;
+    case 'database':
+      markdown += '# Search Results (Databases)\n\n';
+      break;
+    case 'block':
+      markdown += '# Block Contents\n\n';
+      break;
+    default:
+      markdown += '# Results List\n\n';
+  }
+
+  // Process each result
+  for (const item of list.results) {
+    // Convert based on type
+    switch (item.object) {
+      case 'page':
+        if (resultType === 'page') {
+          // Display page title and link
+          const title = extractPageTitle(item) || 'Untitled';
+          markdown += `## [${title}](${item.url || '#'})\n\n`;
+          markdown += `ID: \`${item.id}\`\n\n`;
+          // Separator line
+          markdown += '---\n\n';
+        } else {
+          // Full conversion
+          markdown += convertPageToMarkdown(item);
+          markdown += '\n\n---\n\n';
+        }
+        break;
+        
+      case 'database':
+        if (resultType === 'database') {
+          // Simple display
+          const dbTitle = extractRichText(item.title || []) || 'Untitled Database';
+          markdown += `## [${dbTitle}](${item.url || '#'})\n\n`;
+          markdown += `ID: \`${item.id}\`\n\n`;
+          markdown += '---\n\n';
+        } else {
+          // Full conversion
+          markdown += convertDatabaseToMarkdown(item);
+          markdown += '\n\n---\n\n';
+        }
+        break;
+        
+      case 'block':
+        markdown += renderBlock(item);
+        markdown += '\n\n';
+        break;
+        
+      default:
+        markdown += `\`\`\`json\n${JSON.stringify(item, null, 2)}\n\`\`\`\n\n`;
+    }
+  }
+
+  // Include pagination info if available
+  if (list.has_more) {
+    markdown += '\n> More results available. Use `start_cursor` parameter with the next request.\n';
+    if (list.next_cursor) {
+      markdown += `> Next cursor: \`${list.next_cursor}\`\n`;
+    }
+  }
+
+  return markdown;
+}
+
+/**
+ * Extracts page title
+ */
+function extractPageTitle(page: any): string {
+  if (!page || !page.properties) return '';
+  
+  // Look for the title property
+  for (const [_, prop] of Object.entries(page.properties)) {
+    const property = prop as any;
+    if (property.type === 'title' && Array.isArray(property.title)) {
+      return extractRichText(property.title);
+    }
+  }
+  
+  return '';
+}
+
+/**
+ * Converts page properties to Markdown
+ */
+function convertPropertiesToMarkdown(properties: any): string {
+  if (!properties) return '';
+  
+  let markdown = '## Properties\n\n';
+  
+  // Display properties as a key-value table
+  markdown += '| Property | Value |\n';
+  markdown += '|------------|----|\n';
+  
+  for (const [key, prop] of Object.entries(properties)) {
+    const property = prop as any;
+    const propName = property.id || key;
+    let propValue = '';
+    
+    // Extract value based on property type
+    switch (property.type) {
+      case 'title':
+        propValue = extractRichText(property.title || []);
+        break;
+      case 'rich_text':
+        propValue = extractRichText(property.rich_text || []);
+        break;
+      case 'number':
+        propValue = property.number?.toString() || '';
+        break;
+      case 'select':
+        propValue = property.select?.name || '';
+        break;
+      case 'multi_select':
+        propValue = (property.multi_select || [])
+          .map((item: any) => item.name)
+          .join(', ');
+        break;
+      case 'date':
+        const start = property.date?.start || '';
+        const end = property.date?.end ? ` → ${property.date.end}` : '';
+        propValue = start + end;
+        break;
+      case 'people':
+        propValue = (property.people || [])
+          .map((person: any) => person.name || person.id)
+          .join(', ');
+        break;
+      case 'files':
+        propValue = (property.files || [])
+          .map((file: any) => `[${file.name || 'Attachment'}](${file.file?.url || file.external?.url || '#'})`)
+          .join(', ');
+        break;
+      case 'checkbox':
+        propValue = property.checkbox ? '✓' : '✗';
+        break;
+      case 'url':
+        propValue = property.url || '';
+        break;
+      case 'email':
+        propValue = property.email || '';
+        break;
+      case 'phone_number':
+        propValue = property.phone_number || '';
+        break;
+      case 'formula':
+        propValue = property.formula?.string || 
+                   property.formula?.number?.toString() || 
+                   property.formula?.boolean?.toString() || '';
+        break;
+      default:
+        propValue = '(Unsupported property type)';
+    }
+    
+    markdown += `| ${escapeTableCell(propName)} | ${escapeTableCell(propValue)} |\n`;
+  }
+  
+  return markdown;
+}
+
+/**
+ * Extracts plain text from a Notion rich text array
+ */
+function extractRichText(richTextArray: any[]): string {
+  if (!richTextArray || !Array.isArray(richTextArray)) return '';
+  
+  return richTextArray
+    .map(item => {
+      let text = item.plain_text || '';
+      
+      // Process annotations
+      if (item.annotations) {
+        const { bold, italic, strikethrough, code } = item.annotations;
+        
+        if (code) text = `\`${text}\``;
+        if (bold) text = `**${text}**`;
+        if (italic) text = `*${text}*`;
+        if (strikethrough) text = `~~${text}~~`;
+      }
+      
+      // Process links
+      if (item.href) {
+        text = `[${text}](${item.href})`;
+      }
+      
+      return text;
+    })
+    .join('');
+}
+
+/**
+ * Converts a block to Markdown
+ */
+function renderBlock(block: any): string {
+  if (!block) return '';
+  
+  const blockType = block.type;
+  if (!blockType) return '';
+  
+  // Get block content
+  const blockContent = block[blockType];
+  if (!blockContent && blockType !== 'divider') return '';
+
+  switch (blockType) {
+    case 'paragraph':
+      return renderParagraph(blockContent);
+      
+    case 'heading_1':
+      return `# ${extractRichText(blockContent.rich_text || [])}`;
+      
+    case 'heading_2':
+      return `## ${extractRichText(blockContent.rich_text || [])}`;
+      
+    case 'heading_3':
+      return `### ${extractRichText(blockContent.rich_text || [])}`;
+      
+    case 'bulleted_list_item':
+      return `- ${extractRichText(blockContent.rich_text || [])}`;
+      
+    case 'numbered_list_item':
+      return `1. ${extractRichText(blockContent.rich_text || [])}`;
+      
+    case 'to_do':
+      const checked = blockContent.checked ? 'x' : ' ';
+      return `- [${checked}] ${extractRichText(blockContent.rich_text || [])}`;
+      
+    case 'toggle':
+      return `<details>\n<summary>${extractRichText(blockContent.rich_text || [])}</summary>\n\n*Additional API request is needed to display child blocks*\n\n</details>`;
+      
+    case 'child_page':
+      return `📄 **Child Page**: ${blockContent.title || 'Untitled'}`;
+      
+    case 'image':
+      const imageType = blockContent.type || '';
+      const imageUrl = imageType === 'external' 
+        ? blockContent.external?.url 
+        : blockContent.file?.url;
+      const imageCaption = extractRichText(blockContent.caption || []) || 'image';
+      return `![${imageCaption}](${imageUrl || '#'})`;
+      
+    case 'divider':
+      return '---';
+      
+    case 'quote':
+      return `> ${extractRichText(blockContent.rich_text || [])}`;
+      
+    case 'code':
+      const codeLanguage = blockContent.language || 'plaintext';
+      const codeContent = extractRichText(blockContent.rich_text || []);
+      return `\`\`\`${codeLanguage}\n${codeContent}\n\`\`\``;
+      
+    case 'callout':
+      const calloutIcon = blockContent.icon?.emoji || '';
+      const calloutText = extractRichText(blockContent.rich_text || []);
+      return `> ${calloutIcon} ${calloutText}`;
+      
+    case 'bookmark':
+      const bookmarkUrl = blockContent.url || '';
+      const bookmarkCaption = extractRichText(blockContent.caption || []) || bookmarkUrl;
+      return `[${bookmarkCaption}](${bookmarkUrl})`;
+      
+    case 'table':
+      return `*Table data (${blockContent.table_width || 0} columns) - Additional API request is needed to display details*`;
+      
+    case 'child_database':
+      return `📊 **Embedded Database**: \`${block.id}\``;
+      
+    default:
+      return `*Unsupported block type: ${blockType}*`;
+  }
+}
+
+/**
+ * Renders a paragraph block
+ */
+function renderParagraph(paragraph: any): string {
+  if (!paragraph || !paragraph.rich_text) return '';
+  
+  return extractRichText(paragraph.rich_text);
+}
+
+/**
+ * Escapes characters that need special handling in Markdown table cells
+ */
+function escapeTableCell(text: string): string {
+  if (!text) return '';
+  return text.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+} 

--- a/notion/src/markdown/index.ts
+++ b/notion/src/markdown/index.ts
@@ -472,6 +472,78 @@ function renderBlock(block: BlockResponse): string {
     case 'child_database':
       return `📊 **Embedded Database**: \`${block.id}\``;
       
+    case 'breadcrumb':
+      return `[breadcrumb navigation]`;
+
+    case 'embed':
+      const embedUrl = blockContent.url || '';
+      return `<iframe src="${embedUrl}" frameborder="0"></iframe>`;
+      
+    case 'equation':
+      const formulaText = blockContent.expression || '';
+      return `$$${formulaText}$$`;
+      
+    case 'file':
+      const fileType = blockContent.type || '';
+      const fileUrl = fileType === 'external' 
+        ? blockContent.external?.url 
+        : blockContent.file?.url;
+      const fileName = blockContent.name || 'File';
+      return `📎 [${fileName}](${fileUrl || '#'})`;
+      
+    case 'link_preview':
+      const previewUrl = blockContent.url || '';
+      return `🔗 [Preview](${previewUrl})`;
+      
+    case 'link_to_page':
+      let linkText = 'Link to page';
+      let linkId = '';
+      if (blockContent.page_id) {
+        linkId = blockContent.page_id;
+        linkText = 'Link to page';
+      } else if (blockContent.database_id) {
+        linkId = blockContent.database_id;
+        linkText = 'Link to database';
+      }
+      return `🔗 **${linkText}**: \`${linkId}\``;
+      
+    case 'pdf':
+      const pdfType = blockContent.type || '';
+      const pdfUrl = pdfType === 'external' 
+        ? blockContent.external?.url 
+        : blockContent.file?.url;
+      const pdfCaption = extractRichText(blockContent.caption || []) || 'PDF';
+      return `📄 [${pdfCaption}](${pdfUrl || '#'})`;
+      
+    case 'synced_block':
+      const syncedFrom = blockContent.synced_from 
+        ? `\`${blockContent.synced_from.block_id}\`` 
+        : 'original';
+      return `*Synced Block (${syncedFrom}) - Additional API request is needed to display content*`;
+      
+    case 'table_of_contents':
+      return `[TOC]`;
+      
+    case 'table_row':
+      if (!blockContent.cells || !Array.isArray(blockContent.cells)) {
+        return '*Empty table row*';
+      }
+      return `| ${blockContent.cells.map((cell: any) => escapeTableCell(extractRichText(cell))).join(' | ')} |`;
+      
+    case 'template':
+      return `*Template Block: ${extractRichText(blockContent.rich_text || [])}*`;
+      
+    case 'video':
+      const videoType = blockContent.type || '';
+      const videoUrl = videoType === 'external' 
+        ? blockContent.external?.url 
+        : blockContent.file?.url;
+      const videoCaption = extractRichText(blockContent.caption || []) || 'Video';
+      return `🎬 [${videoCaption}](${videoUrl || '#'})`;
+      
+    case 'unsupported':
+      return `*Unsupported block*`;
+
     default:
       return `*Unsupported block type: ${blockType}*`;
   }

--- a/notion/src/markdown/index.ts
+++ b/notion/src/markdown/index.ts
@@ -47,11 +47,6 @@ function convertPageToMarkdown(page: PageResponse): string {
   markdown += '\n\n> This page contains child blocks. You can retrieve them using `retrieveBlockChildren`.\n';
   markdown += `> Block ID: \`${page.id}\`\n`;
 
-  // Include page URL if available
-  if (page.url) {
-    markdown += `\n[View in Notion](${page.url})\n`;
-  }
-
   return markdown;
 }
 
@@ -97,18 +92,57 @@ function convertDatabaseToMarkdown(database: DatabaseResponse): string {
         case 'formula':
           details = `Formula: ${prop.formula?.expression || ''}`;
           break;
-        // Add other property types as needed
+        case 'rollup':
+          details = `Rollup: ${prop.rollup?.function || ''}`;
+          break;
+        case 'created_by':
+        case 'last_edited_by':
+          details = 'User reference';
+          break;
+        case 'created_time':
+        case 'last_edited_time':
+          details = 'Timestamp';
+          break;
+        case 'date':
+          details = 'Date or date range';
+          break;
+        case 'email':
+          details = 'Email address';
+          break;
+        case 'files':
+          details = 'File attachments';
+          break;
+        case 'number':
+          details = `Format: ${prop.number?.format || 'plain number'}`;
+          break;
+        case 'people':
+          details = 'People reference';
+          break;
+        case 'phone_number':
+          details = 'Phone number';
+          break;
+        case 'rich_text':
+          details = 'Formatted text';
+          break;
+        case 'status':
+          const statusOptions = prop.status?.options || [];
+          details = `Options: ${statusOptions.map((o: any) => o.name).join(', ')}`;
+          break;
+        case 'title':
+          details = 'Database title';
+          break;
+        case 'url':
+          details = 'URL link';
+          break;
+        case 'checkbox':
+          details = 'Boolean value';
+          break;
       }
       
       markdown += `| ${escapeTableCell(propName)} | ${propType} | ${escapeTableCell(details)} |\n`;
     });
     
     markdown += '\n';
-  }
-
-  // Include database URL if available
-  if (database.url) {
-    markdown += `\n[View in Notion](${database.url})\n`;
   }
 
   return markdown;
@@ -294,6 +328,32 @@ function convertPropertiesToMarkdown(properties: Record<string, PageProperty>): 
         break;
       case 'status':
         propValue = property.status?.name || '';
+        break;
+      case 'relation':
+        propValue = (property.relation || [])
+          .map((relation: any) => `\`${relation.id}\``)
+          .join(', ');
+        break;
+      case 'rollup':
+        if (property.rollup?.type === 'array') {
+          propValue = JSON.stringify(property.rollup.array || []);
+        } else {
+          propValue = property.rollup?.number?.toString() || 
+                     property.rollup?.date?.start || 
+                     property.rollup?.string || '';
+        }
+        break;
+      case 'created_by':
+        propValue = property.created_by?.name || property.created_by?.id || '';
+        break;
+      case 'created_time':
+        propValue = property.created_time || '';
+        break;
+      case 'last_edited_by':
+        propValue = property.last_edited_by?.name || property.last_edited_by?.id || '';
+        break;
+      case 'last_edited_time':
+        propValue = property.last_edited_time || '';
         break;
       default:
         propValue = '(Unsupported property type)';

--- a/notion/src/markdown/index.ts
+++ b/notion/src/markdown/index.ts
@@ -56,6 +56,11 @@ function convertPageToMarkdown(page: PageResponse): string {
     "\n\n> This page contains child blocks. You can retrieve them using `retrieveBlockChildren`.\n";
   markdown += `> Block ID: \`${page.id}\`\n`;
 
+  // Add link to view the page in Notion
+  if (page.url) {
+    markdown += `\n[View in Notion](${page.url})\n`;
+  }
+
   return markdown;
 }
 
@@ -156,6 +161,11 @@ function convertDatabaseToMarkdown(database: DatabaseResponse): string {
     });
 
     markdown += "\n";
+  }
+
+  // Add link to view the database in Notion
+  if (database.url) {
+    markdown += `\n[View in Notion](${database.url})\n`;
   }
 
   return markdown;

--- a/notion/src/markdown/index.ts
+++ b/notion/src/markdown/index.ts
@@ -1,7 +1,15 @@
 /**
  * Utilities for converting Notion API responses to Markdown
  */
-import { NotionResponse, PageResponse, DatabaseResponse, BlockResponse, ListResponse, RichTextItemResponse, PageProperty } from "../types/index.js";
+import {
+  NotionResponse,
+  PageResponse,
+  DatabaseResponse,
+  BlockResponse,
+  ListResponse,
+  RichTextItemResponse,
+  PageProperty,
+} from "../types/index.js";
 
 /**
  * Converts Notion API response to Markdown
@@ -10,17 +18,17 @@ import { NotionResponse, PageResponse, DatabaseResponse, BlockResponse, ListResp
  */
 export function convertToMarkdown(response: NotionResponse): string {
   // Execute appropriate conversion process based on response type
-  if (!response) return '';
-  
+  if (!response) return "";
+
   // Branch processing by object type
   switch (response.object) {
-    case 'page':
+    case "page":
       return convertPageToMarkdown(response as PageResponse);
-    case 'database':
+    case "database":
       return convertDatabaseToMarkdown(response as DatabaseResponse);
-    case 'block':
+    case "block":
       return convertBlockToMarkdown(response as BlockResponse);
-    case 'list':
+    case "list":
       return convertListToMarkdown(response as ListResponse);
     default:
       // Return JSON string if conversion is not possible
@@ -32,7 +40,7 @@ export function convertToMarkdown(response: NotionResponse): string {
  * Converts a Notion page to Markdown
  */
 function convertPageToMarkdown(page: PageResponse): string {
-  let markdown = '';
+  let markdown = "";
 
   // Extract title (from properties)
   const title = extractPageTitle(page);
@@ -44,7 +52,8 @@ function convertPageToMarkdown(page: PageResponse): string {
   markdown += convertPropertiesToMarkdown(page.properties);
 
   // Include additional information if there are child blocks
-  markdown += '\n\n> This page contains child blocks. You can retrieve them using `retrieveBlockChildren`.\n';
+  markdown +=
+    "\n\n> This page contains child blocks. You can retrieve them using `retrieveBlockChildren`.\n";
   markdown += `> Block ID: \`${page.id}\`\n`;
 
   return markdown;
@@ -54,7 +63,7 @@ function convertPageToMarkdown(page: PageResponse): string {
  * Converts a Notion database to Markdown
  */
 function convertDatabaseToMarkdown(database: DatabaseResponse): string {
-  let markdown = '';
+  let markdown = "";
 
   // Extract database title
   const title = extractRichText(database.title || []);
@@ -70,79 +79,83 @@ function convertDatabaseToMarkdown(database: DatabaseResponse): string {
 
   // Display database property schema
   if (database.properties) {
-    markdown += '## Properties\n\n';
-    markdown += '| Property Name | Type | Details |\n';
-    markdown += '|------------|------|------|\n';
+    markdown += "## Properties\n\n";
+    markdown += "| Property Name | Type | Details |\n";
+    markdown += "|------------|------|------|\n";
 
     Object.entries(database.properties).forEach(([key, prop]) => {
       const propName = prop.name || key;
-      const propType = prop.type || 'unknown';
-      
+      const propType = prop.type || "unknown";
+
       // Additional information based on property type
-      let details = '';
+      let details = "";
       switch (propType) {
-        case 'select':
-        case 'multi_select':
+        case "select":
+        case "multi_select":
           const options = prop[propType]?.options || [];
-          details = `Options: ${options.map((o: any) => o.name).join(', ')}`;
+          details = `Options: ${options.map((o: any) => o.name).join(", ")}`;
           break;
-        case 'relation':
-          details = `Related DB: ${prop.relation?.database_id || ''}`;
+        case "relation":
+          details = `Related DB: ${prop.relation?.database_id || ""}`;
           break;
-        case 'formula':
-          details = `Formula: ${prop.formula?.expression || ''}`;
+        case "formula":
+          details = `Formula: ${prop.formula?.expression || ""}`;
           break;
-        case 'rollup':
-          details = `Rollup: ${prop.rollup?.function || ''}`;
+        case "rollup":
+          details = `Rollup: ${prop.rollup?.function || ""}`;
           break;
-        case 'created_by':
-        case 'last_edited_by':
-          details = 'User reference';
+        case "created_by":
+        case "last_edited_by":
+          details = "User reference";
           break;
-        case 'created_time':
-        case 'last_edited_time':
-          details = 'Timestamp';
+        case "created_time":
+        case "last_edited_time":
+          details = "Timestamp";
           break;
-        case 'date':
-          details = 'Date or date range';
+        case "date":
+          details = "Date or date range";
           break;
-        case 'email':
-          details = 'Email address';
+        case "email":
+          details = "Email address";
           break;
-        case 'files':
-          details = 'File attachments';
+        case "files":
+          details = "File attachments";
           break;
-        case 'number':
-          details = `Format: ${prop.number?.format || 'plain number'}`;
+        case "number":
+          details = `Format: ${prop.number?.format || "plain number"}`;
           break;
-        case 'people':
-          details = 'People reference';
+        case "people":
+          details = "People reference";
           break;
-        case 'phone_number':
-          details = 'Phone number';
+        case "phone_number":
+          details = "Phone number";
           break;
-        case 'rich_text':
-          details = 'Formatted text';
+        case "rich_text":
+          details = "Formatted text";
           break;
-        case 'status':
+        case "status":
           const statusOptions = prop.status?.options || [];
-          details = `Options: ${statusOptions.map((o: any) => o.name).join(', ')}`;
+          details = `Options: ${statusOptions
+            .map((o: any) => o.name)
+            .join(", ")}`;
           break;
-        case 'title':
-          details = 'Database title';
+        case "title":
+          details = "Database title";
           break;
-        case 'url':
-          details = 'URL link';
+        case "url":
+          details = "URL link";
           break;
-        case 'checkbox':
-          details = 'Boolean value';
+        case "checkbox":
+          details = "Boolean value";
           break;
       }
-      
-      markdown += `| ${escapeTableCell(propName)} | ${propType} | ${escapeTableCell(details)} |\n`;
+
+      markdown += `| ${escapeTableCell(
+        propName
+      )} | ${propType} | ${escapeTableCell(details)} |\n`;
     });
-    
-    markdown += '\n';
+
+    markdown += "\n";
   }
 
   return markdown;
@@ -152,7 +165,7 @@ function convertDatabaseToMarkdown(database: DatabaseResponse): string {
  * Converts Notion API block response to Markdown
  */
 function convertBlockToMarkdown(block: BlockResponse): string {
-  if (!block) return '';
+  if (!block) return "";
 
   // Convert based on block type
   return renderBlock(block);
@@ -163,68 +176,72 @@ function convertBlockToMarkdown(block: BlockResponse): string {
  */
 function convertListToMarkdown(list: ListResponse): string {
   if (!list || !list.results || !Array.isArray(list.results)) {
-    return '```\nNo results\n```';
+    return "```\nNo results\n```";
   }
 
-  let markdown = '';
-  
+  let markdown = "";
+
   // Determine the type of results
   const firstResult = list.results[0];
-  const resultType = firstResult?.object || 'unknown';
-  
+  const resultType = firstResult?.object || "unknown";
+
   // Add header based on type
   switch (resultType) {
-    case 'page':
-      markdown += '# Search Results (Pages)\n\n';
+    case "page":
+      markdown += "# Search Results (Pages)\n\n";
       break;
-    case 'database':
-      markdown += '# Search Results (Databases)\n\n';
+    case "database":
+      markdown += "# Search Results (Databases)\n\n";
       break;
-    case 'block':
-      markdown += '# Block Contents\n\n';
+    case "block":
+      markdown += "# Block Contents\n\n";
       break;
     default:
-      markdown += '# Results List\n\n';
+      markdown += "# Results List\n\n";
   }
 
   // Process each result
   for (const item of list.results) {
     // Convert based on type
     switch (item.object) {
-      case 'page':
-        if (resultType === 'page') {
+      case "page":
+        if (resultType === "page") {
           // Display page title and link
-          const title = extractPageTitle(item as PageResponse) || 'Untitled';
-          markdown += `## [${title}](${(item as PageResponse).url || '#'})\n\n`;
+          const title = extractPageTitle(item as PageResponse) || "Untitled";
+          markdown += `## [${title}](${(item as PageResponse).url || "#"})\n\n`;
           markdown += `ID: \`${item.id}\`\n\n`;
           // Separator line
-          markdown += '---\n\n';
+          markdown += "---\n\n";
         } else {
           // Full conversion
           markdown += convertPageToMarkdown(item as PageResponse);
-          markdown += '\n\n---\n\n';
+          markdown += "\n\n---\n\n";
         }
         break;
-        
-      case 'database':
-        if (resultType === 'database') {
+
+      case "database":
+        if (resultType === "database") {
           // Simple display
-          const dbTitle = extractRichText((item as DatabaseResponse).title || []) || 'Untitled Database';
-          markdown += `## [${dbTitle}](${(item as DatabaseResponse).url || '#'})\n\n`;
+          const dbTitle =
+            extractRichText((item as DatabaseResponse).title || []) ||
+            "Untitled Database";
+          markdown += `## [${dbTitle}](${
+            (item as DatabaseResponse).url || "#"
+          })\n\n`;
           markdown += `ID: \`${item.id}\`\n\n`;
-          markdown += '---\n\n';
+          markdown += "---\n\n";
         } else {
           // Full conversion
           markdown += convertDatabaseToMarkdown(item as DatabaseResponse);
-          markdown += '\n\n---\n\n';
+          markdown += "\n\n---\n\n";
         }
         break;
-        
-      case 'block':
+
+      case "block":
         markdown += renderBlock(item as BlockResponse);
-        markdown += '\n\n';
+        markdown += "\n\n";
         break;
-        
+
       default:
         markdown += `\`\`\`json\n${JSON.stringify(item, null, 2)}\n\`\`\`\n\n`;
     }
@@ -232,7 +249,8 @@ function convertListToMarkdown(list: ListResponse): string {
 
   // Include pagination info if available
   if (list.has_more) {
-    markdown += '\n> More results available. Use `start_cursor` parameter with the next request.\n';
+    markdown +=
+      "\n> More results available. Use `start_cursor` parameter with the next request.\n";
     if (list.next_cursor) {
       markdown += `> Next cursor: \`${list.next_cursor}\`\n`;
     }
@@ -245,123 +263,137 @@ function convertListToMarkdown(list: ListResponse): string {
  * Extracts page title
  */
 function extractPageTitle(page: PageResponse): string {
-  if (!page || !page.properties) return '';
-  
+  if (!page || !page.properties) return "";
+
   // Look for the title property
   for (const [_, prop] of Object.entries(page.properties)) {
     const property = prop as PageProperty;
-    if (property.type === 'title' && Array.isArray(property.title)) {
+    if (property.type === "title" && Array.isArray(property.title)) {
       return extractRichText(property.title);
     }
   }
-  
-  return '';
+
+  return "";
 }
 
 /**
  * Converts page properties to Markdown
  */
-function convertPropertiesToMarkdown(properties: Record<string, PageProperty>): string {
-  if (!properties) return '';
-  
-  let markdown = '## Properties\n\n';
-  
+function convertPropertiesToMarkdown(
+  properties: Record<string, PageProperty>
+): string {
+  if (!properties) return "";
+
+  let markdown = "## Properties\n\n";
+
   // Display properties as a key-value table
-  markdown += '| Property | Value |\n';
-  markdown += '|------------|----|\n';
-  
+  markdown += "| Property | Value |\n";
+  markdown += "|------------|----|\n";
+
   for (const [key, prop] of Object.entries(properties)) {
     const property = prop as PageProperty;
     const propName = key;
-    let propValue = '';
-    
+    let propValue = "";
+
     // Extract value based on property type
     switch (property.type) {
-      case 'title':
+      case "title":
         propValue = extractRichText(property.title || []);
         break;
-      case 'rich_text':
+      case "rich_text":
         propValue = extractRichText(property.rich_text || []);
         break;
-      case 'number':
-        propValue = property.number?.toString() || '';
+      case "number":
+        propValue = property.number?.toString() || "";
         break;
-      case 'select':
-        propValue = property.select?.name || '';
+      case "select":
+        propValue = property.select?.name || "";
         break;
-      case 'multi_select':
+      case "multi_select":
         propValue = (property.multi_select || [])
           .map((item: any) => item.name)
-          .join(', ');
+          .join(", ");
         break;
-      case 'date':
-        const start = property.date?.start || '';
-        const end = property.date?.end ? ` → ${property.date.end}` : '';
+      case "date":
+        const start = property.date?.start || "";
+        const end = property.date?.end ? ` → ${property.date.end}` : "";
         propValue = start + end;
         break;
-      case 'people':
+      case "people":
         propValue = (property.people || [])
           .map((person: any) => person.name || person.id)
-          .join(', ');
+          .join(", ");
         break;
-      case 'files':
+      case "files":
         propValue = (property.files || [])
-          .map((file: any) => `[${file.name || 'Attachment'}](${file.file?.url || file.external?.url || '#'})`)
-          .join(', ');
+          .map(
+            (file: any) =>
+              `[${file.name || "Attachment"}](${
+                file.file?.url || file.external?.url || "#"
+              })`
+          )
+          .join(", ");
         break;
-      case 'checkbox':
-        propValue = property.checkbox ? '✓' : '✗';
+      case "checkbox":
+        propValue = property.checkbox ? "✓" : "✗";
         break;
-      case 'url':
-        propValue = property.url || '';
+      case "url":
+        propValue = property.url || "";
         break;
-      case 'email':
-        propValue = property.email || '';
+      case "email":
+        propValue = property.email || "";
         break;
-      case 'phone_number':
-        propValue = property.phone_number || '';
+      case "phone_number":
+        propValue = property.phone_number || "";
         break;
-      case 'formula':
-        propValue = property.formula?.string || 
-                   property.formula?.number?.toString() || 
-                   property.formula?.boolean?.toString() || '';
+      case "formula":
+        propValue =
+          property.formula?.string ||
+          property.formula?.number?.toString() ||
+          property.formula?.boolean?.toString() ||
+          "";
         break;
-      case 'status':
-        propValue = property.status?.name || '';
+      case "status":
+        propValue = property.status?.name || "";
         break;
-      case 'relation':
+      case "relation":
         propValue = (property.relation || [])
           .map((relation: any) => `\`${relation.id}\``)
-          .join(', ');
+          .join(", ");
         break;
-      case 'rollup':
-        if (property.rollup?.type === 'array') {
+      case "rollup":
+        if (property.rollup?.type === "array") {
           propValue = JSON.stringify(property.rollup.array || []);
         } else {
-          propValue = property.rollup?.number?.toString() || 
-                     property.rollup?.date?.start || 
-                     property.rollup?.string || '';
+          propValue =
+            property.rollup?.number?.toString() ||
+            property.rollup?.date?.start ||
+            property.rollup?.string ||
+            "";
         }
         break;
-      case 'created_by':
-        propValue = property.created_by?.name || property.created_by?.id || '';
+      case "created_by":
+        propValue = property.created_by?.name || property.created_by?.id || "";
         break;
-      case 'created_time':
-        propValue = property.created_time || '';
+      case "created_time":
+        propValue = property.created_time || "";
         break;
-      case 'last_edited_by':
-        propValue = property.last_edited_by?.name || property.last_edited_by?.id || '';
+      case "last_edited_by":
+        propValue =
+          property.last_edited_by?.name || property.last_edited_by?.id || "";
         break;
-      case 'last_edited_time':
-        propValue = property.last_edited_time || '';
+      case "last_edited_time":
+        propValue = property.last_edited_time || "";
         break;
       default:
-        propValue = '(Unsupported property type)';
+        propValue = "(Unsupported property type)";
     }
-    
-    markdown += `| ${escapeTableCell(propName)} | ${escapeTableCell(propValue)} |\n`;
+
+    markdown += `| ${escapeTableCell(propName)} | ${escapeTableCell(
+      propValue
+    )} |\n`;
   }
-  
+
   return markdown;
 }
 
@@ -369,179 +401,194 @@ function convertPropertiesToMarkdown(properties: Record<string, PageProperty>): 
  * Extracts plain text from a Notion rich text array
  */
 function extractRichText(richTextArray: RichTextItemResponse[]): string {
-  if (!richTextArray || !Array.isArray(richTextArray)) return '';
-  
+  if (!richTextArray || !Array.isArray(richTextArray)) return "";
+
   return richTextArray
-    .map(item => {
-      let text = item.plain_text || '';
-      
+    .map((item) => {
+      let text = item.plain_text || "";
+
       // Process annotations
       if (item.annotations) {
         const { bold, italic, strikethrough, code } = item.annotations;
-        
+
         if (code) text = `\`${text}\``;
         if (bold) text = `**${text}**`;
         if (italic) text = `*${text}*`;
         if (strikethrough) text = `~~${text}~~`;
       }
-      
+
       // Process links
       if (item.href) {
         text = `[${text}](${item.href})`;
       }
-      
+
       return text;
     })
-    .join('');
+    .join("");
 }
 
 /**
  * Converts a block to Markdown
  */
 function renderBlock(block: BlockResponse): string {
-  if (!block) return '';
-  
+  if (!block) return "";
+
   const blockType = block.type;
-  if (!blockType) return '';
-  
+  if (!blockType) return "";
+
   // Get block content
   const blockContent = block[blockType];
-  if (!blockContent && blockType !== 'divider') return '';
+  if (!blockContent && blockType !== "divider") return "";
 
   switch (blockType) {
-    case 'paragraph':
+    case "paragraph":
       return renderParagraph(blockContent);
-      
-    case 'heading_1':
+
+    case "heading_1":
       return `# ${extractRichText(blockContent.rich_text || [])}`;
-      
-    case 'heading_2':
+
+    case "heading_2":
       return `## ${extractRichText(blockContent.rich_text || [])}`;
-      
-    case 'heading_3':
+
+    case "heading_3":
       return `### ${extractRichText(blockContent.rich_text || [])}`;
-      
-    case 'bulleted_list_item':
+
+    case "bulleted_list_item":
       return `- ${extractRichText(blockContent.rich_text || [])}`;
-      
-    case 'numbered_list_item':
+
+    case "numbered_list_item":
       return `1. ${extractRichText(blockContent.rich_text || [])}`;
-      
-    case 'to_do':
-      const checked = blockContent.checked ? 'x' : ' ';
+
+    case "to_do":
+      const checked = blockContent.checked ? "x" : " ";
       return `- [${checked}] ${extractRichText(blockContent.rich_text || [])}`;
-      
-    case 'toggle':
-      return `<details>\n<summary>${extractRichText(blockContent.rich_text || [])}</summary>\n\n*Additional API request is needed to display child blocks*\n\n</details>`;
-      
-    case 'child_page':
-      return `📄 **Child Page**: ${blockContent.title || 'Untitled'}`;
-      
-    case 'image':
-      const imageType = blockContent.type || '';
-      const imageUrl = imageType === 'external' 
-        ? blockContent.external?.url 
-        : blockContent.file?.url;
-      const imageCaption = extractRichText(blockContent.caption || []) || 'image';
-      return `![${imageCaption}](${imageUrl || '#'})`;
-      
-    case 'divider':
-      return '---';
-      
-    case 'quote':
+
+    case "toggle":
+      return `<details>\n<summary>${extractRichText(
+        blockContent.rich_text || []
+      )}</summary>\n\n*Additional API request is needed to display child blocks*\n\n</details>`;
+
+    case "child_page":
+      return `📄 **Child Page**: ${blockContent.title || "Untitled"}`;
+
+    case "image":
+      const imageType = blockContent.type || "";
+      const imageUrl =
+        imageType === "external"
+          ? blockContent.external?.url
+          : blockContent.file?.url;
+      const imageCaption =
+        extractRichText(blockContent.caption || []) || "image";
+      return `![${imageCaption}](${imageUrl || "#"})`;
+
+    case "divider":
+      return "---";
+
+    case "quote":
       return `> ${extractRichText(blockContent.rich_text || [])}`;
-      
-    case 'code':
-      const codeLanguage = blockContent.language || 'plaintext';
+
+    case "code":
+      const codeLanguage = blockContent.language || "plaintext";
       const codeContent = extractRichText(blockContent.rich_text || []);
       return `\`\`\`${codeLanguage}\n${codeContent}\n\`\`\``;
-      
-    case 'callout':
-      const calloutIcon = blockContent.icon?.emoji || '';
+
+    case "callout":
+      const calloutIcon = blockContent.icon?.emoji || "";
       const calloutText = extractRichText(blockContent.rich_text || []);
       return `> ${calloutIcon} ${calloutText}`;
-      
-    case 'bookmark':
-      const bookmarkUrl = blockContent.url || '';
-      const bookmarkCaption = extractRichText(blockContent.caption || []) || bookmarkUrl;
+
+    case "bookmark":
+      const bookmarkUrl = blockContent.url || "";
+      const bookmarkCaption =
+        extractRichText(blockContent.caption || []) || bookmarkUrl;
       return `[${bookmarkCaption}](${bookmarkUrl})`;
-      
-    case 'table':
-      return `*Table data (${blockContent.table_width || 0} columns) - Additional API request is needed to display details*`;
-      
-    case 'child_database':
+
+    case "table":
+      return `*Table data (${
+        blockContent.table_width || 0
+      } columns) - Additional API request is needed to display details*`;
+
+    case "child_database":
       return `📊 **Embedded Database**: \`${block.id}\``;
-      
-    case 'breadcrumb':
+
+    case "breadcrumb":
       return `[breadcrumb navigation]`;
 
-    case 'embed':
-      const embedUrl = blockContent.url || '';
+    case "embed":
+      const embedUrl = blockContent.url || "";
       return `<iframe src="${embedUrl}" frameborder="0"></iframe>`;
-      
-    case 'equation':
-      const formulaText = blockContent.expression || '';
+
+    case "equation":
+      const formulaText = blockContent.expression || "";
       return `$$${formulaText}$$`;
-      
-    case 'file':
-      const fileType = blockContent.type || '';
-      const fileUrl = fileType === 'external' 
-        ? blockContent.external?.url 
-        : blockContent.file?.url;
-      const fileName = blockContent.name || 'File';
-      return `📎 [${fileName}](${fileUrl || '#'})`;
-      
-    case 'link_preview':
-      const previewUrl = blockContent.url || '';
+
+    case "file":
+      const fileType = blockContent.type || "";
+      const fileUrl =
+        fileType === "external"
+          ? blockContent.external?.url
+          : blockContent.file?.url;
+      const fileName = blockContent.name || "File";
+      return `📎 [${fileName}](${fileUrl || "#"})`;
+
+    case "link_preview":
+      const previewUrl = blockContent.url || "";
       return `🔗 [Preview](${previewUrl})`;
-      
-    case 'link_to_page':
-      let linkText = 'Link to page';
-      let linkId = '';
+
+    case "link_to_page":
+      let linkText = "Link to page";
+      let linkId = "";
       if (blockContent.page_id) {
         linkId = blockContent.page_id;
-        linkText = 'Link to page';
+        linkText = "Link to page";
       } else if (blockContent.database_id) {
         linkId = blockContent.database_id;
-        linkText = 'Link to database';
+        linkText = "Link to database";
       }
       return `🔗 **${linkText}**: \`${linkId}\``;
-      
-    case 'pdf':
-      const pdfType = blockContent.type || '';
-      const pdfUrl = pdfType === 'external' 
-        ? blockContent.external?.url 
-        : blockContent.file?.url;
-      const pdfCaption = extractRichText(blockContent.caption || []) || 'PDF';
-      return `📄 [${pdfCaption}](${pdfUrl || '#'})`;
-      
-    case 'synced_block':
-      const syncedFrom = blockContent.synced_from 
-        ? `\`${blockContent.synced_from.block_id}\`` 
-        : 'original';
+
+    case "pdf":
+      const pdfType = blockContent.type || "";
+      const pdfUrl =
+        pdfType === "external"
+          ? blockContent.external?.url
+          : blockContent.file?.url;
+      const pdfCaption = extractRichText(blockContent.caption || []) || "PDF";
+      return `📄 [${pdfCaption}](${pdfUrl || "#"})`;
+
+    case "synced_block":
+      const syncedFrom = blockContent.synced_from
+        ? `\`${blockContent.synced_from.block_id}\``
+        : "original";
       return `*Synced Block (${syncedFrom}) - Additional API request is needed to display content*`;
-      
-    case 'table_of_contents':
+
+    case "table_of_contents":
       return `[TOC]`;
-      
-    case 'table_row':
+
+    case "table_row":
       if (!blockContent.cells || !Array.isArray(blockContent.cells)) {
-        return '*Empty table row*';
+        return "*Empty table row*";
       }
-      return `| ${blockContent.cells.map((cell: any) => escapeTableCell(extractRichText(cell))).join(' | ')} |`;
-      
-    case 'template':
-      return `*Template Block: ${extractRichText(blockContent.rich_text || [])}*`;
-      
-    case 'video':
-      const videoType = blockContent.type || '';
-      const videoUrl = videoType === 'external' 
-        ? blockContent.external?.url 
-        : blockContent.file?.url;
-      const videoCaption = extractRichText(blockContent.caption || []) || 'Video';
-      return `🎬 [${videoCaption}](${videoUrl || '#'})`;
-      
-    case 'unsupported':
+      return `| ${blockContent.cells
+        .map((cell: any) => escapeTableCell(extractRichText(cell)))
+        .join(" | ")} |`;
+
+    case "template":
+      return `*Template Block: ${extractRichText(
+        blockContent.rich_text || []
+      )}*`;
+
+    case "video":
+      const videoType = blockContent.type || "";
+      const videoUrl =
+        videoType === "external"
+          ? blockContent.external?.url
+          : blockContent.file?.url;
+      const videoCaption =
+        extractRichText(blockContent.caption || []) || "Video";
+      return `🎬 [${videoCaption}](${videoUrl || "#"})`;
+
+    case "unsupported":
       return `*Unsupported block*`;
 
     default:
@@ -553,8 +600,8 @@ function renderBlock(block: BlockResponse): string {
  * Renders a paragraph block
  */
 function renderParagraph(paragraph: any): string {
-  if (!paragraph || !paragraph.rich_text) return '';
-  
+  if (!paragraph || !paragraph.rich_text) return "";
+
   return extractRichText(paragraph.rich_text);
 }
 
@@ -562,6 +609,6 @@ function renderParagraph(paragraph: any): string {
  * Escapes characters that need special handling in Markdown table cells
  */
 function escapeTableCell(text: string): string {
-  if (!text) return '';
-  return text.replace(/\|/g, '\\|').replace(/\n/g, ' ').replace(/\+/g, '\\+');
-} 
+  if (!text) return "";
+  return text.replace(/\|/g, "\\|").replace(/\n/g, " ").replace(/\+/g, "\\+");
+}

--- a/notion/src/types/index.ts
+++ b/notion/src/types/index.ts
@@ -2,10 +2,16 @@
  * Type definitions for Notion API responses
  */
 
-export type NotionObjectType = 'page' | 'database' | 'block' | 'list' | 'user' | 'comment';
+export type NotionObjectType =
+  | "page"
+  | "database"
+  | "block"
+  | "list"
+  | "user"
+  | "comment";
 
 export type RichTextItemResponse = {
-  type: 'text' | 'mention' | 'equation';
+  type: "text" | "mention" | "equation";
   text?: {
     content: string;
     link?: {
@@ -13,7 +19,13 @@ export type RichTextItemResponse = {
     } | null;
   };
   mention?: {
-    type: 'database' | 'date' | 'link_preview' | 'page' | 'template_mention' | 'user';
+    type:
+      | "database"
+      | "date"
+      | "link_preview"
+      | "page"
+      | "template_mention"
+      | "user";
     [key: string]: any;
   };
   annotations?: {
@@ -31,42 +43,42 @@ export type RichTextItemResponse = {
   };
 };
 
-export type BlockType = 
-  | 'paragraph'
-  | 'heading_1'
-  | 'heading_2'
-  | 'heading_3'
-  | 'bulleted_list_item'
-  | 'numbered_list_item'
-  | 'to_do'
-  | 'toggle'
-  | 'child_page'
-  | 'child_database'
-  | 'embed'
-  | 'callout'
-  | 'quote'
-  | 'equation'
-  | 'divider'
-  | 'table_of_contents'
-  | 'column'
-  | 'column_list'
-  | 'link_preview'
-  | 'synced_block'
-  | 'template'
-  | 'link_to_page'
-  | 'audio'
-  | 'bookmark'
-  | 'breadcrumb'
-  | 'code'
-  | 'file'
-  | 'image'
-  | 'pdf'
-  | 'video'
-  | 'unsupported'
+export type BlockType =
+  | "paragraph"
+  | "heading_1"
+  | "heading_2"
+  | "heading_3"
+  | "bulleted_list_item"
+  | "numbered_list_item"
+  | "to_do"
+  | "toggle"
+  | "child_page"
+  | "child_database"
+  | "embed"
+  | "callout"
+  | "quote"
+  | "equation"
+  | "divider"
+  | "table_of_contents"
+  | "column"
+  | "column_list"
+  | "link_preview"
+  | "synced_block"
+  | "template"
+  | "link_to_page"
+  | "audio"
+  | "bookmark"
+  | "breadcrumb"
+  | "code"
+  | "file"
+  | "image"
+  | "pdf"
+  | "video"
+  | "unsupported"
   | string;
 
 export type BlockResponse = {
-  object: 'block';
+  object: "block";
   id: string;
   type: BlockType;
   created_time: string;
@@ -77,16 +89,16 @@ export type BlockResponse = {
 };
 
 export type PageResponse = {
-  object: 'page';
+  object: "page";
   id: string;
   created_time: string;
   last_edited_time: string;
   created_by?: {
-    object: 'user';
+    object: "user";
     id: string;
   };
   last_edited_by?: {
-    object: 'user';
+    object: "user";
     id: string;
   };
   cover?: {
@@ -102,7 +114,7 @@ export type PageResponse = {
   url?: string;
   public_url?: string;
   parent: {
-    type: 'database_id' | 'page_id' | 'workspace';
+    type: "database_id" | "page_id" | "workspace";
     database_id?: string;
     page_id?: string;
   };
@@ -116,7 +128,7 @@ export type PageProperty = {
 };
 
 export type DatabaseResponse = {
-  object: 'database';
+  object: "database";
   id: string;
   created_time: string;
   last_edited_time: string;
@@ -150,8 +162,14 @@ export type DatabasePropertyConfig = {
 };
 
 export type ListResponse = {
-  object: 'list';
-  results: Array<PageResponse | DatabaseResponse | BlockResponse | UserResponse | CommentResponse>;
+  object: "list";
+  results: Array<
+    | PageResponse
+    | DatabaseResponse
+    | BlockResponse
+    | UserResponse
+    | CommentResponse
+  >;
   next_cursor: string | null;
   has_more: boolean;
   type?: string;
@@ -159,11 +177,11 @@ export type ListResponse = {
 };
 
 export type UserResponse = {
-  object: 'user';
+  object: "user";
   id: string;
   name?: string;
   avatar_url?: string | null;
-  type?: 'person' | 'bot';
+  type?: "person" | "bot";
   person?: {
     email: string;
   };
@@ -171,10 +189,10 @@ export type UserResponse = {
 };
 
 export type CommentResponse = {
-  object: 'comment';
+  object: "comment";
   id: string;
   parent: {
-    type: 'page_id' | 'block_id';
+    type: "page_id" | "block_id";
     page_id?: string;
     block_id?: string;
   };
@@ -182,16 +200,16 @@ export type CommentResponse = {
   created_time: string;
   last_edited_time: string;
   created_by: {
-    object: 'user';
+    object: "user";
     id: string;
   };
   rich_text: RichTextItemResponse[];
 };
 
-export type NotionResponse = 
-  | PageResponse 
-  | DatabaseResponse 
-  | BlockResponse 
-  | ListResponse 
-  | UserResponse 
-  | CommentResponse; 
+export type NotionResponse =
+  | PageResponse
+  | DatabaseResponse
+  | BlockResponse
+  | ListResponse
+  | UserResponse
+  | CommentResponse;

--- a/notion/src/types/index.ts
+++ b/notion/src/types/index.ts
@@ -1,0 +1,197 @@
+/**
+ * Type definitions for Notion API responses
+ */
+
+export type NotionObjectType = 'page' | 'database' | 'block' | 'list' | 'user' | 'comment';
+
+export type RichTextItemResponse = {
+  type: 'text' | 'mention' | 'equation';
+  text?: {
+    content: string;
+    link?: {
+      url: string;
+    } | null;
+  };
+  mention?: {
+    type: 'database' | 'date' | 'link_preview' | 'page' | 'template_mention' | 'user';
+    [key: string]: any;
+  };
+  annotations?: {
+    bold: boolean;
+    italic: boolean;
+    strikethrough: boolean;
+    underline: boolean;
+    code: boolean;
+    color: string;
+  };
+  plain_text?: string;
+  href?: string | null;
+  equation?: {
+    expression: string;
+  };
+};
+
+export type BlockType = 
+  | 'paragraph'
+  | 'heading_1'
+  | 'heading_2'
+  | 'heading_3'
+  | 'bulleted_list_item'
+  | 'numbered_list_item'
+  | 'to_do'
+  | 'toggle'
+  | 'child_page'
+  | 'child_database'
+  | 'embed'
+  | 'callout'
+  | 'quote'
+  | 'equation'
+  | 'divider'
+  | 'table_of_contents'
+  | 'column'
+  | 'column_list'
+  | 'link_preview'
+  | 'synced_block'
+  | 'template'
+  | 'link_to_page'
+  | 'audio'
+  | 'bookmark'
+  | 'breadcrumb'
+  | 'code'
+  | 'file'
+  | 'image'
+  | 'pdf'
+  | 'video'
+  | 'unsupported'
+  | string;
+
+export type BlockResponse = {
+  object: 'block';
+  id: string;
+  type: BlockType;
+  created_time: string;
+  last_edited_time: string;
+  has_children?: boolean;
+  archived?: boolean;
+  [key: string]: any;
+};
+
+export type PageResponse = {
+  object: 'page';
+  id: string;
+  created_time: string;
+  last_edited_time: string;
+  created_by?: {
+    object: 'user';
+    id: string;
+  };
+  last_edited_by?: {
+    object: 'user';
+    id: string;
+  };
+  cover?: {
+    type: string;
+    [key: string]: any;
+  } | null;
+  icon?: {
+    type: string;
+    [key: string]: any;
+  } | null;
+  archived?: boolean;
+  in_trash?: boolean;
+  url?: string;
+  public_url?: string;
+  parent: {
+    type: 'database_id' | 'page_id' | 'workspace';
+    database_id?: string;
+    page_id?: string;
+  };
+  properties: Record<string, PageProperty>;
+};
+
+export type PageProperty = {
+  id: string;
+  type: string;
+  [key: string]: any;
+};
+
+export type DatabaseResponse = {
+  object: 'database';
+  id: string;
+  created_time: string;
+  last_edited_time: string;
+  title: RichTextItemResponse[];
+  description?: RichTextItemResponse[];
+  url?: string;
+  icon?: {
+    type: string;
+    emoji?: string;
+    [key: string]: any;
+  } | null;
+  cover?: {
+    type: string;
+    [key: string]: any;
+  } | null;
+  properties: Record<string, DatabasePropertyConfig>;
+  parent?: {
+    type: string;
+    page_id?: string;
+    workspace?: boolean;
+  };
+  archived?: boolean;
+  is_inline?: boolean;
+};
+
+export type DatabasePropertyConfig = {
+  id: string;
+  name: string;
+  type: string;
+  [key: string]: any;
+};
+
+export type ListResponse = {
+  object: 'list';
+  results: Array<PageResponse | DatabaseResponse | BlockResponse | UserResponse | CommentResponse>;
+  next_cursor: string | null;
+  has_more: boolean;
+  type?: string;
+  page_or_database?: Record<string, any>;
+};
+
+export type UserResponse = {
+  object: 'user';
+  id: string;
+  name?: string;
+  avatar_url?: string | null;
+  type?: 'person' | 'bot';
+  person?: {
+    email: string;
+  };
+  bot?: Record<string, any>;
+};
+
+export type CommentResponse = {
+  object: 'comment';
+  id: string;
+  parent: {
+    type: 'page_id' | 'block_id';
+    page_id?: string;
+    block_id?: string;
+  };
+  discussion_id: string;
+  created_time: string;
+  last_edited_time: string;
+  created_by: {
+    object: 'user';
+    id: string;
+  };
+  rich_text: RichTextItemResponse[];
+};
+
+export type NotionResponse = 
+  | PageResponse 
+  | DatabaseResponse 
+  | BlockResponse 
+  | ListResponse 
+  | UserResponse 
+  | CommentResponse; 


### PR DESCRIPTION
[issue](https://github.com/suekou/mcp-notion-server/issues/14)

- I have modified it so that responses from Notion are converted to markdown.

TODO:
- If functions other than retrieving Notion content are used, a separate tool must be created, as the original state (information that has not been converted to markdown) is required.
- Since the created converter has not yet been tested, tests need to be developed and verified.
- Additionally, since the markdown converter created this time is a simple one, I am considering the addition of extra types and functions.