### PR TITLE
[BUGFIX: ISSUE 24] replace console errors with info for informational messaging

### DIFF
--- a/notion/src/index.ts
+++ b/notion/src/index.ts
@@ -1075,6 +1075,7 @@ async function main() {
     process.exit(1);
   }
 
+  console.info("Starting Notion MCP Server...");
   const server = new Server(
     {
       name: "Notion MCP Server",
@@ -1092,7 +1093,7 @@ async function main() {
   server.setRequestHandler(
     CallToolRequestSchema,
     async (request: CallToolRequest) => {
-      console.error("Received CallToolRequest:", request);
+      console.info("Received CallToolRequest:", request);
       try {
         if (!request.params.arguments) {
           throw new Error("No arguments provided");
@@ -1353,6 +1354,7 @@ async function main() {
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
+    console.info("Received ListToolsRequest");
     return {
       tools: [
         appendBlockChildrenTool,
@@ -1377,7 +1379,10 @@ async function main() {
   });
 
   const transport = new StdioServerTransport();
+  console.info("Connecting server to transport...");
   await server.connect(transport);
+
+  console.info("Notion MCP Server running on stdio");
 }
 
 main().catch((error) => {


### PR DESCRIPTION
[Reported issue](https://github.com/suekou/mcp-notion-server/issues/24)

There are multiple instances of `console.error` being used for informational messaging. This is causing an issue with cline believing that the MCP server is erroring out when its actually in a healthy state. I reviewed all the uses of `console.error` and replaced the non error handling instances with `console.info`

<img width="412" alt="Screenshot 2025-03-21 at 12 39 38 PM" src="https://github.com/user-attachments/assets/b996b36d-b53d-4323-87c5-79de93f1b45b" />
