### PR TITLE
use string for boolean in NOTION_MARKDOWN_CONVERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ By default, all responses are returned in JSON format. You can enable experiment
       "args": ["-y", "@suekou/mcp-notion-server"],
       "env": {
         "NOTION_API_TOKEN": "your-integration-token",
-        "NOTION_MARKDOWN_CONVERSION": true
+        "NOTION_MARKDOWN_CONVERSION": "true"
       }
     }
   }
@@ -95,7 +95,7 @@ or
       "args": ["your-built-file-path"],
       "env": {
         "NOTION_API_TOKEN": "your-integration-token",
-        "NOTION_MARKDOWN_CONVERSION": true
+        "NOTION_MARKDOWN_CONVERSION": "true"
       }
     }
   }


### PR DESCRIPTION
updates the docs to use a string for it's reference of the `NOTION_MARKDOWN_CONVERSION` boolean

without this change, you get a type error: 

<img width="307" alt="image" src="https://github.com/user-attachments/assets/d0295837-929d-4007-a1d7-19e2da010df7" />
