### PR TITLE
Fix: Add missing items schema to query and update database tools

### DIFF
--- a/notion/src/index.ts
+++ b/notion/src/index.ts
@@ -697,6 +697,18 @@ const queryDatabaseTool: Tool = {
       sorts: {
         type: "array",
         description: "Sort conditions",
+        items: {
+          type: "object",
+          properties: {
+            property: { type: "string" },
+            timestamp: { type: "string" },
+            direction: {
+              type: "string",
+              enum: ["ascending", "descending"]
+            }
+          },
+          required: ["direction"]
+        }
       },
       start_cursor: {
         type: "string",
@@ -749,6 +761,7 @@ const updateDatabaseTool: Tool = {
         type: "array",
         description:
           "An array of rich text objects that represents the description of the database that is displayed in the Notion UI.",
+        items: richTextObjectSchema,
       },
       properties: {
         type: "object",


### PR DESCRIPTION
This PR resolves schema validation errors in the notion_query_database and notion_update_database tools used by the Notion MCP server.

✅ Fixes:
	•	query_database: Added items schema for the sorts property.
	•	update_database: Added items schema for the description property.

These changes fix the following OpenAI API error messages:
	•	"Invalid schema for function 'notion_query_database': In context=('properties', 'sorts'), array schema missing items."
	•	"Invalid schema for function 'notion_update_database': In context=('properties', 'description'), array schema missing items."

🔧 Result & Testing

Tested locally.
The Notion agent now correctly registers these tools with OpenAI’s function calling format, allowing query_database and update_database to work as intended.