### PR TITLE
Changed the `title` parameter to optional when creating a database in both `README.md` and `index.ts`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ All tools support the following optional parameter:
    - Create a new database.
    - Required inputs:
      - `parent` (object): Parent object of the database.
-     - `title` (array): Title of the database as a rich text array.
      - `properties` (object): Property schema of the database.
+   - Optional inputs:
+     - `title` (array): Title of the database as a rich text array.
    - Returns: Information about the created database.
 
 8. `notion_query_database`

--- a/notion/src/index.ts
+++ b/notion/src/index.ts
@@ -112,7 +112,7 @@ interface CreateDatabaseArgs {
     database_id?: string;
     workspace?: boolean;
   };
-  title: RichTextItemResponse[];
+  title?: RichTextItemResponse[];
   properties: Record<string, any>;
   format?: "json" | "markdown";
 }
@@ -1075,8 +1075,8 @@ export class NotionClientWrapper {
 
   async createDatabase(
     parent: CreateDatabaseArgs["parent"],
-    title: RichTextItemResponse[],
-    properties: Record<string, any>
+    properties: Record<string, any>,
+    title?: RichTextItemResponse[],
   ): Promise<DatabaseResponse> {
     const body = { parent, title, properties };
 
@@ -1413,8 +1413,8 @@ async function main() {
               .arguments as unknown as CreateDatabaseArgs;
             response = await notionClient.createDatabase(
               args.parent,
-              args.title,
-              args.properties
+              args.properties,
+              args.title
             );
             break;
           }


### PR DESCRIPTION
Added a description of the optional input to `README.md`.
ref: https://github.com/suekou/mcp-notion-server/issues/25