### PR TITLE
Add auto-pagination, new tools, and comprehensive documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [Unreleased] — 2026-04-10
+
+### Added
+
+- **Auto-pagination for `notion_query_database`** — Automatically loops through all pages of results (100 per request) until exhausted. Returns the complete dataset in a single response. The `start_cursor` and `page_size` parameters have been removed from this tool since pagination is now handled internally.
+
+- **Auto-pagination for `notion_search`** — Same auto-pagination behavior as `notion_query_database`. Loops until `has_more` is false, returns everything.
+
+- **`notion_create_page` tool** — Create pages under any parent type (page or database). Supports content blocks (`children`), `icon`, and `cover` in addition to `properties`. This is a superset of `notion_create_database_item`, which is retained for backward compatibility.
+
+- **`notion_archive_page` tool** — Archive or restore a page by setting `archived` to `true` or `false`.
+
+- **`notion_retrieve_page_property_item` tool** — Retrieve a specific property value from a page. Auto-paginates for property types that return lists (relations, rollups, rich_text, title, people).
+
+- **Install script (`install.sh`)** — Interactive installer that checks prerequisites, installs dependencies, builds the project, and outputs a ready-to-paste MCP client config. Supports non-interactive mode via `NOTION_API_TOKEN` env var.
+
+- **`CLAUDE.md`** — Project documentation for AI-assisted development, covering architecture, tools, build/run instructions, and configuration.
+
+- **`skills/` directory** — Usage guides for common Notion operations:
+  - `query-database.md` — Querying databases with filters and sorts
+  - `search-workspace.md` — Searching across the workspace
+  - `create-update-pages.md` — Creating, updating, and archiving pages
+  - `work-with-blocks.md` — Reading, appending, updating, and deleting blocks
+
+- **`agents/` directory** — Agent definitions for complex workflows:
+  - `report-generator.md` — Query a database and produce a structured report
+  - `workspace-search.md` — Search and summarize content across Notion
+
+- **`CHANGELOG.md`** — This file.
+
+- **Auto-pagination tests** — New test cases verifying multi-page pagination for `queryDatabase` and `search` methods.
+
+### Changed
+
+- **`notion_query_database` schema** — Removed `start_cursor` and `page_size` parameters (auto-pagination handles this). Updated description to reflect auto-pagination.
+
+- **`notion_search` schema** — Removed `start_cursor` and `page_size` parameters. Updated description.
+
+- **README.md** — Complete rewrite with disclaimer about fork origin and AI-assisted development, quick install instructions, table-formatted tool reference, and auto-pagination documentation.
+
+- **Tool count** — 18 tools → 21 tools.
+
+## [1.2.4] — Prior release (upstream)
+
+Upstream release from [@suekou/mcp-notion-server](https://github.com/suekou/mcp-notion-server). See the [original repository](https://github.com/suekou/mcp-notion-server) for prior history.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Unified MCP server for the Notion API, replacing both the official Notion MCP and the suekou MCP with a single, complete implementation built on the public Notion REST API.
 
+Forked from [@suekou/mcp-notion-server](https://github.com/suekou/mcp-notion-server). Modifications are AI-assisted (vibe coded with Claude).
+
 ## Architecture
 
 ```
@@ -19,12 +21,14 @@ src/
     index.ts            # Notion response → Markdown conversion
     index.test.ts       # Tests for markdown conversion
   utils/index.ts        # Tool filtering utility
+skills/                 # Usage guides for common Notion operations
+agents/                 # Agent definitions for complex workflows
 ```
 
 ## Tools (21 total)
 
 **Blocks:** append_block_children, retrieve_block, retrieve_block_children, delete_block, update_block
-**Pages:** retrieve_page, update_page_properties, create_page, archive_page, retrieve_page_property_item
+**Pages:** retrieve_page, create_page, update_page_properties, archive_page, retrieve_page_property_item
 **Databases:** create_database, query_database (auto-paginated), retrieve_database, update_database, create_database_item
 **Users:** list_all_users, retrieve_user, retrieve_bot_user
 **Comments:** create_comment, retrieve_comments
@@ -34,6 +38,8 @@ src/
 
 `notion_query_database` and `notion_search` automatically loop through all pages of results (100 per request) until exhausted, returning the complete dataset in a single response. No manual cursor management needed.
 
+`notion_retrieve_page_property_item` also auto-paginates for property types that return paginated lists (relations, rollups, rich_text, title, people).
+
 ## Build & Run
 
 ```bash
@@ -41,6 +47,12 @@ npm install
 npm run build        # Compile TypeScript → build/
 npm test             # Run vitest tests
 npm run watch        # TypeScript watch mode
+```
+
+### Quick install
+
+```bash
+./install.sh
 ```
 
 ### Run locally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# MCP Notion Server
+
+Unified MCP server for the Notion API, replacing both the official Notion MCP and the suekou MCP with a single, complete implementation built on the public Notion REST API.
+
+## Architecture
+
+```
+src/
+  index.ts              # CLI entry point (env vars, args parsing)
+  client/index.ts       # NotionClientWrapper — all Notion API calls
+  server/index.ts       # MCP server setup, tool dispatch (switch statement)
+  types/
+    args.ts             # Tool argument interfaces
+    schemas.ts          # MCP tool schema definitions
+    responses.ts        # Notion API response types
+    common.ts           # Shared schema components (rich text, blocks)
+    index.ts            # Re-exports all types
+  markdown/
+    index.ts            # Notion response → Markdown conversion
+    index.test.ts       # Tests for markdown conversion
+  utils/index.ts        # Tool filtering utility
+```
+
+## Tools (21 total)
+
+**Blocks:** append_block_children, retrieve_block, retrieve_block_children, delete_block, update_block
+**Pages:** retrieve_page, update_page_properties, create_page, archive_page, retrieve_page_property_item
+**Databases:** create_database, query_database (auto-paginated), retrieve_database, update_database, create_database_item
+**Users:** list_all_users, retrieve_user, retrieve_bot_user
+**Comments:** create_comment, retrieve_comments
+**Search:** search (auto-paginated)
+
+### Auto-pagination
+
+`notion_query_database` and `notion_search` automatically loop through all pages of results (100 per request) until exhausted, returning the complete dataset in a single response. No manual cursor management needed.
+
+## Build & Run
+
+```bash
+npm install
+npm run build        # Compile TypeScript → build/
+npm test             # Run vitest tests
+npm run watch        # TypeScript watch mode
+```
+
+### Run locally
+
+```bash
+NOTION_API_TOKEN=ntn_xxx node build/index.js
+```
+
+### Environment Variables
+
+- `NOTION_API_TOKEN` (required) — Notion integration token
+- `NOTION_MARKDOWN_CONVERSION` — Set to `"true"` to enable markdown response format
+
+### CLI Arguments
+
+- `--enabledTools` — Comma-separated list of tool names to enable (default: all)
+
+## Configure in claude_desktop_config.json
+
+```json
+{
+  "mcpServers": {
+    "notion": {
+      "command": "node",
+      "args": ["/path/to/mcp-notion-server/build/index.js"],
+      "env": {
+        "NOTION_API_TOKEN": "ntn_xxx",
+        "NOTION_MARKDOWN_CONVERSION": "true"
+      }
+    }
+  }
+}
+```
+
+## Notion API
+
+- Base URL: `https://api.notion.com/v1`
+- API Version: `2022-06-28`
+- Auth: Bearer token in Authorization header

--- a/README.md
+++ b/README.md
@@ -1,33 +1,56 @@
 # Notion MCP Server
 
-MCP Server for the Notion API, enabling LLM to interact with Notion workspaces. Additionally, it employs Markdown conversion to reduce context size when communicating with LLMs, optimizing token usage and making interactions more efficient.
+> **Disclaimer:** This is a fork of [@suekou/mcp-notion-server](https://github.com/suekou/mcp-notion-server), originally created by [Kosuke Suenaga](https://github.com/suekou). It has been substantially modified using AI-assisted development (vibe coded with Claude). The additions — auto-pagination, new tools, skills, agents, and documentation — were generated and iterated on with Claude Code. Use at your own discretion; review the code before running in production.
+
+MCP Server for the Notion API, enabling LLMs to interact with Notion workspaces. Supports both JSON and Markdown response formats to optimize token usage.
+
+## Quick Install
+
+```bash
+git clone https://github.com/fenixstarlord/mcp-notion-server.git
+cd mcp-notion-server
+./install.sh
+```
+
+The install script checks prerequisites (Node.js >= 18), installs dependencies, builds the project, and prints a ready-to-paste config snippet. You can also pass the token non-interactively:
+
+```bash
+NOTION_API_TOKEN=ntn_xxx ./install.sh
+```
+
+### Manual Install
+
+```bash
+npm install
+npm run build
+```
 
 ## Setup
 
-Here is a detailed explanation of the steps mentioned above in the following articles:
+1. **Create a Notion Integration** at the [Notion Integrations page](https://www.notion.so/profile/integrations). Give it read/update/insert content and comment permissions as needed.
 
-- English Version: https://dev.to/suekou/operating-notion-via-claude-desktop-using-mcp-c0h
-- Japanese Version: https://qiita.com/suekou/items/44c864583f5e3e6325d9
+2. **Copy the Integration Token** — you'll need it for the `NOTION_API_TOKEN` env var.
 
-1. **Create a Notion Integration**:
+3. **Connect the Integration** — open each Notion page or database you want accessible, click "..." > "Connections", and add your integration.
 
-   - Visit the [Notion Your Integrations page](https://www.notion.so/profile/integrations).
-   - Click "New Integration".
-   - Name your integration and select appropriate permissions (e.g., "Read content", "Update content").
+4. **Configure your MCP client** — add the server to your `claude_desktop_config.json`:
 
-2. **Retrieve the Secret Key**:
+```json
+{
+  "mcpServers": {
+    "notion": {
+      "command": "node",
+      "args": ["/path/to/mcp-notion-server/build/index.js"],
+      "env": {
+        "NOTION_API_TOKEN": "ntn_xxx",
+        "NOTION_MARKDOWN_CONVERSION": "true"
+      }
+    }
+  }
+}
+```
 
-   - Copy the "Internal Integration Token" from your integration.
-   - This token will be used for authentication.
-
-3. **Add the Integration to Your Workspace**:
-
-   - Open the page or database you want the integration to access in Notion.
-   - Click the "···" button in the top right corner.
-   - Click the "Connections" button, and select the the integration you created in step 1 above.
-
-4. **Configure Claude Desktop**:
-   Add the following to your `claude_desktop_config.json`:
+Or via npx (using the original suekou package — does not include the fork additions):
 
 ```json
 {
@@ -36,23 +59,7 @@ Here is a detailed explanation of the steps mentioned above in the following art
       "command": "npx",
       "args": ["-y", "@suekou/mcp-notion-server"],
       "env": {
-        "NOTION_API_TOKEN": "your-integration-token"
-      }
-    }
-  }
-}
-```
-
-or
-
-```json
-{
-  "mcpServers": {
-    "notion": {
-      "command": "node",
-      "args": ["your-built-file-path"],
-      "env": {
-        "NOTION_API_TOKEN": "your-integration-token"
+        "NOTION_API_TOKEN": "ntn_xxx"
       }
     }
   }
@@ -61,270 +68,131 @@ or
 
 ## Environment Variables
 
-- `NOTION_API_TOKEN` (required): Your Notion API integration token.
-- `NOTION_MARKDOWN_CONVERSION`: Set to "true" to enable experimental Markdown conversion. This can significantly reduce token consumption when viewing content, but may cause issues when trying to edit page content.
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `NOTION_API_TOKEN` | Yes | Notion integration token |
+| `NOTION_MARKDOWN_CONVERSION` | No | Set to `"true"` to enable Markdown responses. Reduces token usage significantly but loses the original JSON structure. |
 
-## Command Line Arguments
+## CLI Arguments
 
-- `--enabledTools`: Comma-separated list of tools to enable (e.g. "notion_retrieve_page,notion_query_database"). When specified, only the listed tools will be available. If not specified, all tools are enabled.
+- `--enabledTools` — Comma-separated list of tool names to enable (default: all).
 
-Read-only tools example (copy-paste friendly):
+Read-only mode example:
 
 ```bash
-node build/index.js --enabledTools=notion_retrieve_block,notion_retrieve_block_children,notion_retrieve_page,notion_query_database,notion_retrieve_database,notion_search,notion_list_all_users,notion_retrieve_user,notion_retrieve_bot_user,notion_retrieve_comments
+NOTION_API_TOKEN=ntn_xxx node build/index.js \
+  --enabledTools=notion_retrieve_block,notion_retrieve_block_children,notion_retrieve_page,notion_retrieve_page_property_item,notion_query_database,notion_retrieve_database,notion_search,notion_list_all_users,notion_retrieve_user,notion_retrieve_bot_user,notion_retrieve_comments
 ```
 
-## Advanced Configuration
+## Tools (21)
 
-### Markdown Conversion
+All tools accept an optional `format` parameter (`"json"` or `"markdown"`, default `"markdown"`). Use `"markdown"` for reading, `"json"` when you need to modify content.
 
-By default, all responses are returned in JSON format. You can enable experimental Markdown conversion to reduce token consumption:
+### Blocks
 
-```json
-{
-  "mcpServers": {
-    "notion": {
-      "command": "npx",
-      "args": ["-y", "@suekou/mcp-notion-server"],
-      "env": {
-        "NOTION_API_TOKEN": "your-integration-token",
-        "NOTION_MARKDOWN_CONVERSION": "true"
-      }
-    }
-  }
-}
-```
+| Tool | Description |
+|------|-------------|
+| `notion_append_block_children` | Append child blocks to a parent block. Required: `block_id`, `children`. Optional: `after`. |
+| `notion_retrieve_block` | Retrieve a single block. Required: `block_id`. |
+| `notion_retrieve_block_children` | Retrieve children of a block. Required: `block_id`. Optional: `start_cursor`, `page_size`. |
+| `notion_delete_block` | Delete a block. Required: `block_id`. |
+| `notion_update_block` | Update block content. Required: `block_id`, `block`. |
 
-or
+### Pages
 
-```json
-{
-  "mcpServers": {
-    "notion": {
-      "command": "node",
-      "args": ["your-built-file-path"],
-      "env": {
-        "NOTION_API_TOKEN": "your-integration-token",
-        "NOTION_MARKDOWN_CONVERSION": "true"
-      }
-    }
-  }
-}
-```
+| Tool | Description |
+|------|-------------|
+| `notion_retrieve_page` | Retrieve a page. Required: `page_id`. |
+| `notion_create_page` | Create a page under a page or database. Required: `parent`, `properties`. Optional: `children`, `icon`, `cover`. |
+| `notion_update_page_properties` | Update page properties. Required: `page_id`, `properties`. |
+| `notion_archive_page` | Archive or restore a page. Required: `page_id`, `archived` (boolean). |
+| `notion_retrieve_page_property_item` | Retrieve a specific property value (auto-paginates for relations, rollups, etc.). Required: `page_id`, `property_id`. |
 
-When `NOTION_MARKDOWN_CONVERSION` is set to `"true"`, responses will be converted to Markdown format (when `format` parameter is set to `"markdown"`), making them more human-readable and significantly reducing token consumption. However, since this feature is experimental, it may cause issues when trying to edit page content as the original structure is lost in conversion.
+### Databases
 
-You can control the format on a per-request basis by setting the `format` parameter to either `"json"` or `"markdown"` in your tool calls:
+| Tool | Description |
+|------|-------------|
+| `notion_create_database` | Create a database. Required: `parent`, `properties`. Optional: `title`. |
+| `notion_query_database` | Query a database with filters and sorts. **Auto-paginates** through all results. Required: `database_id`. Optional: `filter`, `sorts`. |
+| `notion_retrieve_database` | Retrieve database schema. Required: `database_id`. |
+| `notion_update_database` | Update database title, description, or properties. Required: `database_id`. Optional: `title`, `description`, `properties`. |
+| `notion_create_database_item` | Create a row in a database. Required: `database_id`, `properties`. |
 
-- Use `"markdown"` for better readability when only viewing content
-- Use `"json"` when you need to modify the returned content
+### Users
 
-## Troubleshooting
+| Tool | Description |
+|------|-------------|
+| `notion_list_all_users` | List workspace users. Optional: `start_cursor`, `page_size`. *(Enterprise plan required)* |
+| `notion_retrieve_user` | Retrieve a user. Required: `user_id`. *(Enterprise plan required)* |
+| `notion_retrieve_bot_user` | Retrieve the bot user for the current token. |
 
-If you encounter permission errors:
+### Comments
 
-1. Ensure the integration has the required permissions.
-2. Verify that the integration is invited to the relevant pages or databases.
-3. Confirm the token and configuration are correctly set in `claude_desktop_config.json`.
+| Tool | Description |
+|------|-------------|
+| `notion_create_comment` | Create a comment on a page or discussion. Required: `rich_text`. Optional: `parent`, `discussion_id`. |
+| `notion_retrieve_comments` | Retrieve comments on a block or page. Required: `block_id`. Optional: `start_cursor`, `page_size`. |
+
+### Search
+
+| Tool | Description |
+|------|-------------|
+| `notion_search` | Search pages and databases by title. **Auto-paginates** through all results. Optional: `query`, `filter`, `sort`. |
+
+## Auto-Pagination
+
+`notion_query_database` and `notion_search` automatically loop through all pages of results (100 per request) until exhausted, returning the complete dataset in a single response. No cursor management needed.
+
+Other paginated endpoints (`notion_retrieve_block_children`, `notion_list_all_users`, `notion_retrieve_comments`) still accept `start_cursor` and `page_size` for manual pagination.
+
+`notion_retrieve_page_property_item` also auto-paginates for property types that return paginated lists (relations, rollups, rich_text, title, people).
+
+## Markdown Conversion
+
+When `NOTION_MARKDOWN_CONVERSION=true`, responses requested with `format: "markdown"` are converted to a readable Markdown format, significantly reducing token consumption. Use `format: "json"` when you need the raw structure for modifications.
 
 ## Project Structure
 
-The project is organized in a modular way to improve maintainability and readability:
-
 ```
-./
-├── src/
-│   ├── index.ts              # Entry point and command-line handling
-│   ├── client/
-│   │   └── index.ts          # NotionClientWrapper class for API interactions
-│   ├── server/
-│   │   └── index.ts          # MCP server setup and request handling
-│   ├── types/
-│   │   ├── index.ts          # Type exports
-│   │   ├── args.ts           # Tool argument interfaces
-│   │   ├── common.ts         # Common schema definitions
-│   │   ├── responses.ts      # API response type definitions
-│   │   └── schemas.ts        # Tool schema definitions
-│   ├── utils/
-│   │   └── index.ts          # Utility functions
-│   └── markdown/
-│       └── index.ts          # Markdown conversion utilities
+src/
+  index.ts              # CLI entry point
+  client/index.ts       # NotionClientWrapper — all API calls
+  server/index.ts       # MCP server setup, tool dispatch
+  types/
+    args.ts             # Tool argument interfaces
+    schemas.ts          # MCP tool schemas
+    responses.ts        # API response types
+    common.ts           # Shared schema definitions
+    index.ts            # Re-exports
+  markdown/
+    index.ts            # JSON → Markdown conversion
+    index.test.ts       # Markdown tests
+  utils/index.ts        # Tool filtering
+skills/                 # Usage guides for common operations
+agents/                 # Agent definitions for complex workflows
 ```
 
-### Directory Descriptions
+## Development
 
-- **index.ts**: Application entry point. Parses command-line arguments and starts the server.
-- **client/**: Module responsible for communication with the Notion API.
-  - **index.ts**: NotionClientWrapper class implements all API calls.
-- **server/**: MCP server implementation.
-  - **index.ts**: Processes requests received from Claude and calls appropriate client methods.
-- **types/**: Type definition module.
-  - **index.ts**: Exports for all types.
-  - **args.ts**: Interface definitions for tool arguments.
-  - **common.ts**: Definitions for common schemas (ID formats, rich text, etc.).
-  - **responses.ts**: Type definitions for Notion API responses.
-  - **schemas.ts**: Definitions for MCP tool schemas.
-- **utils/**: Utility functions.
-  - **index.ts**: Functions like filtering enabled tools.
-- **markdown/**: Markdown conversion functionality.
-  - **index.ts**: Logic for converting JSON responses to Markdown format.
+```bash
+npm install             # Install dependencies
+npm run build           # Compile TypeScript → build/
+npm test                # Run vitest tests
+npm run watch           # TypeScript watch mode
+npm run inspector       # Launch MCP inspector
+```
 
-## Tools
+## Troubleshooting
 
-All tools support the following optional parameter:
-
-- `format` (string, "json" or "markdown", default: "markdown"): Controls the response format. Use "markdown" for human-readable output, "json" for programmatic access to the original data structure. Note: Markdown conversion only works when the `NOTION_MARKDOWN_CONVERSION` environment variable is set to "true".
-
-1. `notion_append_block_children`
-
-   - Append child blocks to a parent block.
-   - Required inputs:
-     - `block_id` (string): The ID of the parent block.
-     - `children` (array): Array of block objects to append.
-   - Returns: Information about the appended blocks.
-
-2. `notion_retrieve_block`
-
-   - Retrieve information about a specific block.
-   - Required inputs:
-     - `block_id` (string): The ID of the block to retrieve.
-   - Returns: Detailed information about the block.
-
-3. `notion_retrieve_block_children`
-
-   - Retrieve the children of a specific block.
-   - Required inputs:
-     - `block_id` (string): The ID of the parent block.
-   - Optional inputs:
-     - `start_cursor` (string): Cursor for the next page of results.
-     - `page_size` (number, default: 100, max: 100): Number of blocks to retrieve.
-   - Returns: List of child blocks.
-
-4. `notion_delete_block`
-
-   - Delete a specific block.
-   - Required inputs:
-     - `block_id` (string): The ID of the block to delete.
-   - Returns: Confirmation of the deletion.
-
-5. `notion_retrieve_page`
-
-   - Retrieve information about a specific page.
-   - Required inputs:
-     - `page_id` (string): The ID of the page to retrieve.
-   - Returns: Detailed information about the page.
-
-6. `notion_update_page_properties`
-
-   - Update properties of a page.
-   - Required inputs:
-     - `page_id` (string): The ID of the page to update.
-     - `properties` (object): Properties to update.
-   - Returns: Information about the updated page.
-
-7. `notion_create_database`
-
-   - Create a new database.
-   - Required inputs:
-     - `parent` (object): Parent object of the database.
-     - `properties` (object): Property schema of the database.
-   - Optional inputs:
-     - `title` (array): Title of the database as a rich text array.
-   - Returns: Information about the created database.
-
-8. `notion_query_database`
-
-   - Query a database.
-   - Required inputs:
-     - `database_id` (string): The ID of the database to query.
-   - Optional inputs:
-     - `filter` (object): Filter conditions.
-     - `sorts` (array): Sorting conditions.
-     - `start_cursor` (string): Cursor for the next page of results.
-     - `page_size` (number, default: 100, max: 100): Number of results to retrieve.
-   - Returns: List of results from the query.
-
-9. `notion_retrieve_database`
-
-   - Retrieve information about a specific database.
-   - Required inputs:
-     - `database_id` (string): The ID of the database to retrieve.
-   - Returns: Detailed information about the database.
-
-10. `notion_update_database`
-
-    - Update information about a database.
-    - Required inputs:
-      - `database_id` (string): The ID of the database to update.
-    - Optional inputs:
-      - `title` (array): New title for the database.
-      - `description` (array): New description for the database.
-      - `properties` (object): Updated property schema.
-    - Returns: Information about the updated database.
-
-11. `notion_create_database_item`
-
-    - Create a new item in a Notion database.
-    - Required inputs:
-      - `database_id` (string): The ID of the database to add the item to.
-      - `properties` (object): The properties of the new item. These should match the database schema.
-    - Returns: Information about the newly created item.
-
-12. `notion_search`
-
-    - Search pages or databases by title.
-    - Optional inputs:
-      - `query` (string): Text to search for in page or database titles.
-      - `filter` (object): Criteria to limit results to either only pages or only databases.
-      - `sort` (object): Criteria to sort the results
-      - `start_cursor` (string): Pagination start cursor.
-      - `page_size` (number, default: 100, max: 100): Number of results to retrieve.
-    - Returns: List of matching pages or databases.
-
-13. `notion_list_all_users`
-
-    - List all users in the Notion workspace.
-    - Note: This function requires upgrading to the Notion Enterprise plan and using an Organization API key to avoid permission errors.
-    - Optional inputs:
-      - start_cursor (string): Pagination start cursor for listing users.
-      - page_size (number, max: 100): Number of users to retrieve.
-    - Returns: A paginated list of all users in the workspace.
-
-14. `notion_retrieve_user`
-
-    - Retrieve a specific user by user_id in Notion.
-    - Note: This function requires upgrading to the Notion Enterprise plan and using an Organization API key to avoid permission errors.
-    - Required inputs:
-      - user_id (string): The ID of the user to retrieve.
-    - Returns: Detailed information about the specified user.
-
-15. `notion_retrieve_bot_user`
-
-    - Retrieve the bot user associated with the current token in Notion.
-    - Returns: Information about the bot user, including details of the person who authorized the integration.
-
-16. `notion_create_comment`
-
-    - Create a comment in Notion.
-    - Requires the integration to have 'insert comment' capabilities.
-    - Either specify a `parent` object with a `page_id` or a `discussion_id`, but not both.
-    - Required inputs:
-      - `rich_text` (array): Array of rich text objects representing the comment content.
-    - Optional inputs:
-      - `parent` (object): Must include `page_id` if used.
-      - `discussion_id` (string): An existing discussion thread ID.
-    - Returns: Information about the created comment.
-
-17. `notion_retrieve_comments`
-    - Retrieve a list of unresolved comments from a Notion page or block.
-    - Requires the integration to have 'read comment' capabilities.
-    - Required inputs:
-      - `block_id` (string): The ID of the block or page whose comments you want to retrieve.
-    - Optional inputs:
-      - `start_cursor` (string): Pagination start cursor.
-      - `page_size` (number, max: 100): Number of comments to retrieve.
-    - Returns: A paginated list of comments associated with the specified block or page.
+- **Permission errors** — Ensure the integration has the required capabilities and is connected to the relevant pages/databases.
+- **Token errors** — Verify `NOTION_API_TOKEN` is set correctly in your config.
+- **Markdown issues** — If editing content after reading in Markdown format fails, switch to `format: "json"` to preserve the original structure.
 
 ## License
 
-This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.
+MIT License. See [LICENSE](LICENSE) for details.
+
+## Credits
+
+- Original project: [@suekou/mcp-notion-server](https://github.com/suekou/mcp-notion-server) by [Kosuke Suenaga](https://github.com/suekou)
+- Fork modifications: AI-assisted development with [Claude Code](https://claude.ai/code)

--- a/agents/report-generator.md
+++ b/agents/report-generator.md
@@ -1,0 +1,54 @@
+# Agent: Notion Report Generator
+
+Generate structured reports from Notion database data.
+
+## System Prompt
+
+You are a report generation agent that queries Notion databases and produces structured reports. You have access to the Notion MCP server tools.
+
+## Workflow
+
+1. **Identify the database** — Use `notion_search` to find the target database by name, or accept a database ID directly.
+
+2. **Retrieve the schema** — Call `notion_retrieve_database` to understand all properties (columns), their types, and available options (e.g., select values).
+
+3. **Query the data** — Call `notion_query_database` with appropriate filters and sorts based on the report requirements. Results are auto-paginated; you receive the complete dataset.
+
+4. **Analyze and structure** — Process the results to extract relevant data points. Group, aggregate, or summarize as needed for the report format.
+
+5. **Generate the report** — Format findings into a clear, structured report with:
+   - Summary/overview section
+   - Key metrics or counts
+   - Detailed breakdown by category
+   - Notable items or outliers
+
+6. **Optionally write back** — If requested, create a new Notion page with the report using `notion_create_page`.
+
+## Example usage
+
+"Generate a status report from the Projects database showing all items due this week grouped by status."
+
+### Agent steps:
+```
+1. notion_search({ query: "Projects", filter: { property: "object", value: "database" } })
+2. notion_retrieve_database({ database_id: "<found_id>" })
+3. notion_query_database({
+     database_id: "<found_id>",
+     filter: {
+       "property": "Due Date",
+       "date": { "this_week": {} }
+     },
+     sorts: [{ "property": "Status", "direction": "ascending" }]
+   })
+4. Process results → group by Status property
+5. Format report with counts per status, list of items per group
+6. Optionally: notion_create_page({ parent: {...}, properties: { title: "Weekly Status Report" }, children: [...report blocks...] })
+```
+
+## Output format
+
+Reports should use markdown with:
+- H2 headers for sections
+- Tables for tabular data
+- Bullet lists for item enumerations
+- Bold for key metrics

--- a/agents/workspace-search.md
+++ b/agents/workspace-search.md
@@ -1,0 +1,52 @@
+# Agent: Notion Workspace Search
+
+Find and summarize content across a Notion workspace.
+
+## System Prompt
+
+You are a workspace search agent that finds relevant content across Notion and provides structured summaries. You have access to the Notion MCP server tools.
+
+## Workflow
+
+1. **Search** — Use `notion_search` with the user's query. Results are auto-paginated and return all matches.
+
+2. **Filter and rank** — Review search results and identify the most relevant pages based on title match and recency (`last_edited_time`).
+
+3. **Retrieve content** — For the top results (typically 3-5), call `notion_retrieve_page` to get properties, then `notion_retrieve_block_children` to get the full page content.
+
+4. **Summarize** — For each relevant page, produce a concise summary including:
+   - Page title and URL
+   - Last edited time
+   - Key content highlights
+   - Relevant properties (if it's a database item)
+
+5. **Synthesize** — Provide an overall summary connecting the findings and answering the user's original question.
+
+## Example usage
+
+"Find everything related to the Q4 marketing campaign."
+
+### Agent steps:
+```
+1. notion_search({ query: "Q4 marketing campaign" })
+2. Review results, pick top 5 most relevant pages
+3. For each page:
+   - notion_retrieve_page({ page_id: "<id>" })
+   - notion_retrieve_block_children({ block_id: "<id>" })
+4. Summarize each page's content
+5. Provide synthesis: "Found 12 pages related to Q4 marketing. The main campaign plan is at [Page Title], with supporting docs for budget, timeline, and creative assets..."
+```
+
+## Search strategies
+
+- **Broad search:** Use a general query, then filter results by relevance
+- **Type-filtered:** Add `filter: { property: "object", value: "page" }` to exclude databases from results
+- **Database-aware:** If results point to database items, use `notion_retrieve_database` to understand the schema, then `notion_query_database` for targeted queries
+- **Iterative:** If initial results are insufficient, try alternative search terms or related keywords
+
+## Output format
+
+Present findings as:
+1. Brief answer to the user's question
+2. List of relevant pages with summaries
+3. Suggested next steps or deeper exploration paths

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install.sh — Quick install for mcp-notion-server
+#
+# Usage:
+#   ./install.sh                  # interactive — prompts for token
+#   NOTION_API_TOKEN=ntn_xxx ./install.sh   # non-interactive
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=== mcp-notion-server installer ==="
+echo ""
+
+# ── 1. Check prerequisites ──────────────────────────────────────────────────
+for cmd in node npm; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "Error: '$cmd' is not installed. Please install Node.js (>=18) first."
+    exit 1
+  fi
+done
+
+NODE_VERSION=$(node -v | sed 's/v//' | cut -d. -f1)
+if [ "$NODE_VERSION" -lt 18 ]; then
+  echo "Error: Node.js >= 18 required (found v$(node -v))."
+  exit 1
+fi
+
+echo "Node.js $(node -v) detected."
+
+# ── 2. Install dependencies & build ─────────────────────────────────────────
+echo ""
+echo "Installing dependencies..."
+cd "$REPO_DIR"
+npm install --no-audit --no-fund 2>&1 | tail -1
+
+echo "Building..."
+npm run build 2>&1 | tail -1
+echo "Build complete: $REPO_DIR/build/index.js"
+
+# ── 3. Notion API token ─────────────────────────────────────────────────────
+if [ -z "${NOTION_API_TOKEN:-}" ]; then
+  echo ""
+  echo "To connect to Notion you need an integration token."
+  echo "Create one at: https://www.notion.so/profile/integrations"
+  echo ""
+  read -rp "Paste your NOTION_API_TOKEN (or press Enter to skip): " NOTION_API_TOKEN
+fi
+
+if [ -z "${NOTION_API_TOKEN:-}" ]; then
+  echo ""
+  echo "No token provided. You can set it later via the NOTION_API_TOKEN env var."
+fi
+
+# ── 4. Print config snippet ─────────────────────────────────────────────────
+ENTRY="$REPO_DIR/build/index.js"
+
+echo ""
+echo "=== Done! ==="
+echo ""
+echo "Add this to your claude_desktop_config.json (or MCP client config):"
+echo ""
+cat <<JSONEOF
+{
+  "mcpServers": {
+    "notion": {
+      "command": "node",
+      "args": ["$ENTRY"],
+      "env": {
+        "NOTION_API_TOKEN": "${NOTION_API_TOKEN:-YOUR_TOKEN_HERE}",
+        "NOTION_MARKDOWN_CONVERSION": "true"
+      }
+    }
+  }
+}
+JSONEOF
+
+echo ""
+echo "Or run directly:"
+echo ""
+echo "  NOTION_API_TOKEN=${NOTION_API_TOKEN:-YOUR_TOKEN_HERE} node $ENTRY"
+echo ""
+
+# ── 5. Optional: run tests ──────────────────────────────────────────────────
+read -rp "Run tests to verify the install? [y/N] " RUN_TESTS
+if [[ "${RUN_TESTS:-n}" =~ ^[Yy]$ ]]; then
+  npm test
+fi
+
+echo ""
+echo "Installation complete."

--- a/skills/create-update-pages.md
+++ b/skills/create-update-pages.md
@@ -1,0 +1,126 @@
+# Skill: Create and Update Notion Pages
+
+Use this skill to create new pages, update existing page properties, archive pages, and manage page content.
+
+## Creating a page under another page
+
+```json
+{
+  "tool": "notion_create_page",
+  "arguments": {
+    "parent": {
+      "type": "page_id",
+      "page_id": "parent-page-id-here"
+    },
+    "properties": {
+      "title": [
+        {
+          "type": "text",
+          "text": { "content": "My New Page" }
+        }
+      ]
+    },
+    "children": [
+      {
+        "object": "block",
+        "type": "paragraph",
+        "paragraph": {
+          "rich_text": [
+            {
+              "type": "text",
+              "text": { "content": "This is the first paragraph." }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Creating a database item
+
+```json
+{
+  "tool": "notion_create_page",
+  "arguments": {
+    "parent": {
+      "type": "database_id",
+      "database_id": "database-id-here"
+    },
+    "properties": {
+      "Name": {
+        "title": [{ "type": "text", "text": { "content": "New Task" } }]
+      },
+      "Status": {
+        "select": { "name": "To Do" }
+      },
+      "Priority": {
+        "select": { "name": "High" }
+      }
+    }
+  }
+}
+```
+
+## Updating page properties
+
+```json
+{
+  "tool": "notion_update_page_properties",
+  "arguments": {
+    "page_id": "page-id-here",
+    "properties": {
+      "Status": { "select": { "name": "Done" } }
+    }
+  }
+}
+```
+
+## Archiving a page
+
+```json
+{
+  "tool": "notion_archive_page",
+  "arguments": {
+    "page_id": "page-id-here",
+    "archived": true
+  }
+}
+```
+
+## Adding content to an existing page
+
+Use `notion_append_block_children` with the page ID as `block_id`:
+
+```json
+{
+  "tool": "notion_append_block_children",
+  "arguments": {
+    "block_id": "page-id-here",
+    "children": [
+      {
+        "object": "block",
+        "type": "heading_2",
+        "heading_2": {
+          "rich_text": [{ "type": "text", "text": { "content": "New Section" } }]
+        }
+      },
+      {
+        "object": "block",
+        "type": "paragraph",
+        "paragraph": {
+          "rich_text": [{ "type": "text", "text": { "content": "Section content here." } }]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Tips
+
+- Always use `notion_retrieve_database` first to understand the property schema before creating database items.
+- Use `format: "json"` when you need to extract property IDs for subsequent updates.
+- Setting a page icon: include `icon: { type: "emoji", emoji: "📝" }` in create_page.
+- Setting a cover: include `cover: { type: "external", external: { url: "https://..." } }`.

--- a/skills/query-database.md
+++ b/skills/query-database.md
@@ -1,0 +1,51 @@
+# Skill: Query a Notion Database
+
+Use this skill to query a Notion database, apply filters and sorts, and generate reports from the results.
+
+## Steps
+
+1. **Get the database ID** — Use `notion_search` with `filter: { property: "object", value: "database" }` to find databases by name, or use `notion_retrieve_database` if you already have the ID.
+
+2. **Understand the schema** — Call `notion_retrieve_database` with the database_id to see all property names and types. This tells you what fields are available for filtering and sorting.
+
+3. **Query with filters** — Call `notion_query_database` with appropriate filter and sort conditions. Results are auto-paginated; you get everything in one call.
+
+## Example: Query a project tracker
+
+```json
+{
+  "tool": "notion_query_database",
+  "arguments": {
+    "database_id": "abc123...",
+    "filter": {
+      "and": [
+        {
+          "property": "Status",
+          "select": { "equals": "In Progress" }
+        },
+        {
+          "property": "Priority",
+          "select": { "equals": "High" }
+        }
+      ]
+    },
+    "sorts": [
+      { "property": "Due Date", "direction": "ascending" }
+    ]
+  }
+}
+```
+
+## Filter syntax reference
+
+- **Text:** `{ "property": "Name", "rich_text": { "contains": "keyword" } }`
+- **Select:** `{ "property": "Status", "select": { "equals": "Done" } }`
+- **Multi-select:** `{ "property": "Tags", "multi_select": { "contains": "urgent" } }`
+- **Date:** `{ "property": "Due", "date": { "before": "2025-01-01" } }`
+- **Checkbox:** `{ "property": "Archived", "checkbox": { "equals": false } }`
+- **Number:** `{ "property": "Score", "number": { "greater_than": 80 } }`
+- **Compound:** Wrap filters in `{ "and": [...] }` or `{ "or": [...] }`
+
+## Interpreting results
+
+Results come as a list of page objects. Each page has a `properties` object with the database columns. Use `format: "markdown"` for readable output, or `format: "json"` when you need to process the data programmatically.

--- a/skills/search-workspace.md
+++ b/skills/search-workspace.md
@@ -1,0 +1,53 @@
+# Skill: Search the Notion Workspace
+
+Use this skill to find pages and databases across the entire Notion workspace.
+
+## Steps
+
+1. **Search by title** — Call `notion_search` with a query string. Results are auto-paginated and return everything matching.
+
+2. **Filter by type** — Use the filter parameter to narrow results to pages or databases only.
+
+3. **Get full content** — For any result, use `notion_retrieve_page` or `notion_retrieve_block_children` to get the full content.
+
+## Example: Find all pages mentioning "Q4 Report"
+
+```json
+{
+  "tool": "notion_search",
+  "arguments": {
+    "query": "Q4 Report",
+    "filter": {
+      "property": "object",
+      "value": "page"
+    },
+    "sort": {
+      "direction": "descending",
+      "timestamp": "last_edited_time"
+    }
+  }
+}
+```
+
+## Example: Find all databases
+
+```json
+{
+  "tool": "notion_search",
+  "arguments": {
+    "query": "",
+    "filter": {
+      "property": "object",
+      "value": "database"
+    }
+  }
+}
+```
+
+## Tips
+
+- The search API matches against page and database **titles only**, not full content.
+- Use `sort` with `last_edited_time` to get most recently edited items first.
+- Results include both pages and databases by default; use `filter` to narrow.
+- After finding a page, use `notion_retrieve_block_children` with the page ID to read its content blocks.
+- After finding a database, use `notion_retrieve_database` to see its schema, then `notion_query_database` to get its rows.

--- a/skills/work-with-blocks.md
+++ b/skills/work-with-blocks.md
@@ -1,0 +1,98 @@
+# Skill: Work with Notion Blocks
+
+Use this skill to read, create, update, and delete content blocks within Notion pages.
+
+## Reading page content
+
+A page's content is stored as child blocks. To read a page's full content:
+
+```json
+{
+  "tool": "notion_retrieve_block_children",
+  "arguments": {
+    "block_id": "page-id-here"
+  }
+}
+```
+
+For nested content (blocks with `has_children: true`), call `notion_retrieve_block_children` again with that block's ID.
+
+## Supported block types
+
+- **Text:** paragraph, heading_1, heading_2, heading_3
+- **Lists:** bulleted_list_item, numbered_list_item, to_do
+- **Layout:** toggle, divider, column_list, column
+- **Media:** image, video, file, pdf, audio, bookmark, embed
+- **Other:** callout, quote, equation, code, table_of_contents, breadcrumb, link_to_page
+
+## Appending blocks
+
+```json
+{
+  "tool": "notion_append_block_children",
+  "arguments": {
+    "block_id": "parent-block-or-page-id",
+    "children": [
+      {
+        "object": "block",
+        "type": "to_do",
+        "to_do": {
+          "rich_text": [{ "type": "text", "text": { "content": "Task item" } }],
+          "checked": false
+        }
+      }
+    ]
+  }
+}
+```
+
+## Updating a block
+
+```json
+{
+  "tool": "notion_update_block",
+  "arguments": {
+    "block_id": "block-id-here",
+    "block": {
+      "paragraph": {
+        "rich_text": [{ "type": "text", "text": { "content": "Updated text" } }]
+      }
+    }
+  }
+}
+```
+
+## Deleting a block
+
+```json
+{
+  "tool": "notion_delete_block",
+  "arguments": {
+    "block_id": "block-id-here"
+  }
+}
+```
+
+## Rich text formatting
+
+Rich text objects support annotations for styling:
+
+```json
+{
+  "type": "text",
+  "text": { "content": "Bold and italic" },
+  "annotations": {
+    "bold": true,
+    "italic": true
+  }
+}
+```
+
+Available annotations: `bold`, `italic`, `strikethrough`, `underline`, `code`, `color`.
+
+## Tips
+
+- Use `notion_retrieve_block` to get a single block's details before updating it.
+- The `after` parameter in `notion_append_block_children` lets you insert blocks at a specific position.
+- Toggle blocks can have children that are revealed when expanded.
+- Headings support `is_toggleable: true` to make them collapsible.

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -140,32 +140,126 @@ describe("NotionClientWrapper", () => {
     const filter = { property: "Status", equals: "Done" };
     const sorts = [{ property: "Due Date", direction: "ascending" }];
 
-    await wrapper.queryDatabase(databaseId, filter, sorts);
+    (fetch as any).mockImplementation(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            object: "list",
+            results: [{ id: "page1" }],
+            has_more: false,
+            next_cursor: null,
+          }),
+      })
+    );
+
+    const result = await wrapper.queryDatabase(databaseId, filter, sorts);
 
     expect(fetch).toHaveBeenCalledWith(
       `https://api.notion.com/v1/databases/${databaseId}/query`,
       {
         method: "POST",
         headers: (wrapper as any).headers,
-        body: JSON.stringify({ filter, sorts }),
+        body: JSON.stringify({ page_size: 100, filter, sorts }),
       }
     );
+    expect(result.results).toEqual([{ id: "page1" }]);
+    expect(result.has_more).toBe(false);
+  });
+
+  test("should auto-paginate queryDatabase through multiple pages", async () => {
+    const databaseId = "db123";
+    let callCount = 0;
+
+    (fetch as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              object: "list",
+              results: [{ id: "page1" }],
+              has_more: true,
+              next_cursor: "cursor_2",
+            }),
+        });
+      }
+      return Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            object: "list",
+            results: [{ id: "page2" }],
+            has_more: false,
+            next_cursor: null,
+          }),
+      });
+    });
+
+    const result = await wrapper.queryDatabase(databaseId);
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(result.results).toEqual([{ id: "page1" }, { id: "page2" }]);
+    expect(result.has_more).toBe(false);
   });
 
   test("should call search with correct parameters", async () => {
     const query = "test query";
     const filter = { property: "object", value: "page" };
 
-    await wrapper.search(query, filter);
-
-    expect(fetch).toHaveBeenCalledWith(
-      "https://api.notion.com/v1/search",
-      {
-        method: "POST",
-        headers: (wrapper as any).headers,
-        body: JSON.stringify({ query, filter }),
-      }
+    (fetch as any).mockImplementation(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            object: "list",
+            results: [{ id: "result1" }],
+            has_more: false,
+            next_cursor: null,
+          }),
+      })
     );
+
+    const result = await wrapper.search(query, filter);
+
+    expect(fetch).toHaveBeenCalledWith("https://api.notion.com/v1/search", {
+      method: "POST",
+      headers: (wrapper as any).headers,
+      body: JSON.stringify({ page_size: 100, query, filter }),
+    });
+    expect(result.results).toEqual([{ id: "result1" }]);
+    expect(result.has_more).toBe(false);
+  });
+
+  test("should auto-paginate search through multiple pages", async () => {
+    let callCount = 0;
+
+    (fetch as any).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              object: "list",
+              results: [{ id: "r1" }],
+              has_more: true,
+              next_cursor: "cur2",
+            }),
+        });
+      }
+      return Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            object: "list",
+            results: [{ id: "r2" }],
+            has_more: false,
+            next_cursor: null,
+          }),
+      });
+    });
+
+    const result = await wrapper.search("test");
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(result.results).toEqual([{ id: "r1" }, { id: "r2" }]);
+    expect(result.has_more).toBe(false);
   });
 
   test("should call toMarkdown method correctly", async () => {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -177,26 +177,37 @@ export class NotionClientWrapper {
       property?: string;
       timestamp?: string;
       direction: "ascending" | "descending";
-    }>,
-    start_cursor?: string,
-    page_size?: number
+    }>
   ): Promise<ListResponse> {
-    const body: Record<string, any> = {};
-    if (filter) body.filter = filter;
-    if (sorts) body.sorts = sorts;
-    if (start_cursor) body.start_cursor = start_cursor;
-    if (page_size) body.page_size = page_size;
+    const allResults: ListResponse["results"] = [];
+    let cursor: string | undefined;
 
-    const response = await fetch(
-      `${this.baseUrl}/databases/${database_id}/query`,
-      {
-        method: "POST",
-        headers: this.headers,
-        body: JSON.stringify(body),
-      }
-    );
+    do {
+      const body: Record<string, any> = { page_size: 100 };
+      if (filter) body.filter = filter;
+      if (sorts) body.sorts = sorts;
+      if (cursor) body.start_cursor = cursor;
 
-    return response.json();
+      const response = await fetch(
+        `${this.baseUrl}/databases/${database_id}/query`,
+        {
+          method: "POST",
+          headers: this.headers,
+          body: JSON.stringify(body),
+        }
+      );
+
+      const page: ListResponse = await response.json();
+      allResults.push(...page.results);
+      cursor = page.has_more ? (page.next_cursor ?? undefined) : undefined;
+    } while (cursor);
+
+    return {
+      object: "list",
+      results: allResults,
+      has_more: false,
+      next_cursor: null,
+    };
   }
 
   async retrieveDatabase(database_id: string): Promise<DatabaseResponse> {
@@ -228,6 +239,27 @@ export class NotionClientWrapper {
     return response.json();
   }
 
+  async createPage(
+    parent: { type: string; page_id?: string; database_id?: string },
+    properties: Record<string, any>,
+    children?: Partial<BlockResponse>[],
+    icon?: { type: string; emoji?: string; external?: { url: string } },
+    cover?: { type: string; external?: { url: string } }
+  ): Promise<PageResponse> {
+    const body: Record<string, any> = { parent, properties };
+    if (children) body.children = children;
+    if (icon) body.icon = icon;
+    if (cover) body.cover = cover;
+
+    const response = await fetch(`${this.baseUrl}/pages`, {
+      method: "POST",
+      headers: this.headers,
+      body: JSON.stringify(body),
+    });
+
+    return response.json();
+  }
+
   async createDatabaseItem(
     database_id: string,
     properties: Record<string, any>
@@ -244,6 +276,62 @@ export class NotionClientWrapper {
     });
 
     return response.json();
+  }
+
+  async archivePage(
+    page_id: string,
+    archived: boolean
+  ): Promise<PageResponse> {
+    const response = await fetch(`${this.baseUrl}/pages/${page_id}`, {
+      method: "PATCH",
+      headers: this.headers,
+      body: JSON.stringify({ archived }),
+    });
+
+    return response.json();
+  }
+
+  async retrievePagePropertyItem(
+    page_id: string,
+    property_id: string
+  ): Promise<any> {
+    const allResults: any[] = [];
+    let cursor: string | undefined;
+    let propertyItem: any;
+
+    do {
+      const params = new URLSearchParams();
+      if (cursor) params.append("start_cursor", cursor);
+      params.append("page_size", "100");
+
+      const response = await fetch(
+        `${this.baseUrl}/pages/${page_id}/properties/${property_id}?${params}`,
+        {
+          method: "GET",
+          headers: this.headers,
+        }
+      );
+
+      propertyItem = await response.json();
+
+      if (propertyItem.object === "list") {
+        allResults.push(...propertyItem.results);
+        cursor = propertyItem.has_more
+          ? (propertyItem.next_cursor ?? undefined)
+          : undefined;
+      } else {
+        return propertyItem;
+      }
+    } while (cursor);
+
+    return {
+      object: "list",
+      results: allResults,
+      has_more: false,
+      next_cursor: null,
+      type: propertyItem?.type,
+      property_item: propertyItem?.property_item,
+    };
   }
 
   async createComment(
@@ -295,24 +383,35 @@ export class NotionClientWrapper {
     sort?: {
       direction: "ascending" | "descending";
       timestamp: "last_edited_time";
-    },
-    start_cursor?: string,
-    page_size?: number
+    }
   ): Promise<ListResponse> {
-    const body: Record<string, any> = {};
-    if (query) body.query = query;
-    if (filter) body.filter = filter;
-    if (sort) body.sort = sort;
-    if (start_cursor) body.start_cursor = start_cursor;
-    if (page_size) body.page_size = page_size;
+    const allResults: ListResponse["results"] = [];
+    let cursor: string | undefined;
 
-    const response = await fetch(`${this.baseUrl}/search`, {
-      method: "POST",
-      headers: this.headers,
-      body: JSON.stringify(body),
-    });
+    do {
+      const body: Record<string, any> = { page_size: 100 };
+      if (query) body.query = query;
+      if (filter) body.filter = filter;
+      if (sort) body.sort = sort;
+      if (cursor) body.start_cursor = cursor;
 
-    return response.json();
+      const response = await fetch(`${this.baseUrl}/search`, {
+        method: "POST",
+        headers: this.headers,
+        body: JSON.stringify(body),
+      });
+
+      const page: ListResponse = await response.json();
+      allResults.push(...page.results);
+      cursor = page.has_more ? (page.next_cursor ?? undefined) : undefined;
+    } while (cursor);
+
+    return {
+      object: "list",
+      results: allResults,
+      has_more: false,
+      next_cursor: null,
+    };
   }
 
   async toMarkdown(response: NotionResponse): Promise<string> {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -169,9 +169,7 @@ export async function startServer(
             response = await notionClient.queryDatabase(
               args.database_id,
               args.filter,
-              args.sorts,
-              args.start_cursor,
-              args.page_size
+              args.sorts
             );
             break;
           }
@@ -216,6 +214,54 @@ export async function startServer(
             break;
           }
 
+          case "notion_create_page": {
+            const args = request.params
+              .arguments as unknown as args.CreatePageArgs;
+            if (!args.parent || !args.properties) {
+              throw new Error(
+                "Missing required arguments: parent and properties"
+              );
+            }
+            response = await notionClient.createPage(
+              args.parent,
+              args.properties,
+              args.children,
+              args.icon,
+              args.cover
+            );
+            break;
+          }
+
+          case "notion_archive_page": {
+            const args = request.params
+              .arguments as unknown as args.ArchivePageArgs;
+            if (!args.page_id || args.archived === undefined) {
+              throw new Error(
+                "Missing required arguments: page_id and archived"
+              );
+            }
+            response = await notionClient.archivePage(
+              args.page_id,
+              args.archived
+            );
+            break;
+          }
+
+          case "notion_retrieve_page_property_item": {
+            const args = request.params
+              .arguments as unknown as args.RetrievePagePropertyItemArgs;
+            if (!args.page_id || !args.property_id) {
+              throw new Error(
+                "Missing required arguments: page_id and property_id"
+              );
+            }
+            response = await notionClient.retrievePagePropertyItem(
+              args.page_id,
+              args.property_id
+            );
+            break;
+          }
+
           case "notion_create_comment": {
             const args = request.params
               .arguments as unknown as args.CreateCommentArgs;
@@ -253,9 +299,7 @@ export async function startServer(
             response = await notionClient.search(
               args.query,
               args.filter,
-              args.sort,
-              args.start_cursor,
-              args.page_size
+              args.sort
             );
             break;
           }
@@ -316,6 +360,9 @@ export async function startServer(
       schemas.retrieveDatabaseTool,
       schemas.updateDatabaseTool,
       schemas.createDatabaseItemTool,
+      schemas.createPageTool,
+      schemas.archivePageTool,
+      schemas.retrievePagePropertyItemTool,
       schemas.createCommentTool,
       schemas.retrieveCommentsTool,
       schemas.searchTool,

--- a/src/types/args.ts
+++ b/src/types/args.ts
@@ -85,8 +85,6 @@ export interface QueryDatabaseArgs {
     timestamp?: string;
     direction: "ascending" | "descending";
   }>;
-  start_cursor?: string;
-  page_size?: number;
   format?: "json" | "markdown";
 }
 
@@ -106,6 +104,27 @@ export interface UpdateDatabaseArgs {
 export interface CreateDatabaseItemArgs {
   database_id: string;
   properties: Record<string, any>;
+  format?: "json" | "markdown";
+}
+
+export interface CreatePageArgs {
+  parent: { type: string; page_id?: string; database_id?: string };
+  properties: Record<string, any>;
+  children?: Partial<BlockResponse>[];
+  icon?: { type: string; emoji?: string; external?: { url: string } };
+  cover?: { type: string; external?: { url: string } };
+  format?: "json" | "markdown";
+}
+
+export interface ArchivePageArgs {
+  page_id: string;
+  archived: boolean;
+  format?: "json" | "markdown";
+}
+
+export interface RetrievePagePropertyItemArgs {
+  page_id: string;
+  property_id: string;
   format?: "json" | "markdown";
 }
 
@@ -132,7 +151,5 @@ export interface SearchArgs {
     direction: "ascending" | "descending";
     timestamp: "last_edited_time";
   };
-  start_cursor?: string;
-  page_size?: number;
   format?: "json" | "markdown";
 }

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -243,7 +243,8 @@ export const createDatabaseTool: Tool = {
 
 export const queryDatabaseTool: Tool = {
   name: "notion_query_database",
-  description: "Query a database in Notion",
+  description:
+    "Query a database in Notion. Automatically paginates through all results and returns the complete dataset.",
   inputSchema: {
     type: "object",
     properties: {
@@ -270,14 +271,6 @@ export const queryDatabaseTool: Tool = {
           },
           required: ["direction"],
         },
-      },
-      start_cursor: {
-        type: "string",
-        description: "Pagination cursor for next page of results",
-      },
-      page_size: {
-        type: "number",
-        description: "Number of results per page (max 100)",
       },
       format: formatParameter,
     },
@@ -357,6 +350,137 @@ export const createDatabaseItemTool: Tool = {
   },
 };
 
+// Page creation tool
+export const createPageTool: Tool = {
+  name: "notion_create_page",
+  description:
+    "Create a new page in Notion. The page can be created as a child of another page or as an item in a database. Supports setting properties, content blocks, icon, and cover image.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      parent: {
+        type: "object",
+        description:
+          "Parent object specifying where to create the page. Use page_id to create a subpage, or database_id to create a database item.",
+        properties: {
+          type: {
+            type: "string",
+            description: "Type of parent: 'page_id' or 'database_id'",
+            enum: ["page_id", "database_id"],
+          },
+          page_id: {
+            type: "string",
+            description:
+              "The ID of the parent page (when type is 'page_id')." +
+              commonIdDescription,
+          },
+          database_id: {
+            type: "string",
+            description:
+              "The ID of the parent database (when type is 'database_id')." +
+              commonIdDescription,
+          },
+        },
+        required: ["type"],
+      },
+      properties: {
+        type: "object",
+        description:
+          "Page properties. For pages under a page, use a 'title' property with a rich text array. For database items, match the database schema.",
+      },
+      children: {
+        type: "array",
+        description: "Array of block objects to add as page content.",
+        items: blockObjectSchema,
+      },
+      icon: {
+        type: "object",
+        description: "Page icon. Use type 'emoji' with an emoji character, or type 'external' with an image URL.",
+        properties: {
+          type: {
+            type: "string",
+            enum: ["emoji", "external"],
+          },
+          emoji: {
+            type: "string",
+            description: "Emoji character (when type is 'emoji')",
+          },
+          external: {
+            type: "object",
+            description: "External image (when type is 'external')",
+            properties: {
+              url: { type: "string", description: "URL of the icon image" },
+            },
+          },
+        },
+      },
+      cover: {
+        type: "object",
+        description: "Page cover image. Must be type 'external' with an image URL.",
+        properties: {
+          type: {
+            type: "string",
+            enum: ["external"],
+          },
+          external: {
+            type: "object",
+            properties: {
+              url: { type: "string", description: "URL of the cover image" },
+            },
+          },
+        },
+      },
+      format: formatParameter,
+    },
+    required: ["parent", "properties"],
+  },
+};
+
+// Archive page tool
+export const archivePageTool: Tool = {
+  name: "notion_archive_page",
+  description:
+    "Archive or restore a page in Notion. Set archived to true to archive, false to restore.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      page_id: {
+        type: "string",
+        description: "The ID of the page to archive or restore." + commonIdDescription,
+      },
+      archived: {
+        type: "boolean",
+        description: "True to archive the page, false to restore it.",
+      },
+      format: formatParameter,
+    },
+    required: ["page_id", "archived"],
+  },
+};
+
+// Retrieve page property item tool
+export const retrievePagePropertyItemTool: Tool = {
+  name: "notion_retrieve_page_property_item",
+  description:
+    "Retrieve a specific property value from a Notion page. Useful for paginated properties like relations, rollups, rich_text, and title. Automatically paginates through all results.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      page_id: {
+        type: "string",
+        description: "The ID of the page." + commonIdDescription,
+      },
+      property_id: {
+        type: "string",
+        description:
+          "The ID of the property to retrieve. You can get property IDs from the page object returned by notion_retrieve_page.",
+      },
+      format: formatParameter,
+    },
+    required: ["page_id", "property_id"],
+  },
+};
+
 // Comments tools
 export const createCommentTool: Tool = {
   name: "notion_create_comment",
@@ -426,7 +550,8 @@ export const retrieveCommentsTool: Tool = {
 // Search tool
 export const searchTool: Tool = {
   name: "notion_search",
-  description: "Search pages or databases by title in Notion",
+  description:
+    "Search pages or databases by title in Notion. Automatically paginates through all results and returns the complete dataset.",
   inputSchema: {
     type: "object",
     properties: {
@@ -461,14 +586,6 @@ export const searchTool: Tool = {
             enum: ["last_edited_time"],
           },
         },
-      },
-      start_cursor: {
-        type: "string",
-        description: "Pagination start cursor",
-      },
-      page_size: {
-        type: "number",
-        description: "Number of results to return (max 100). ",
       },
       format: formatParameter,
     },


### PR DESCRIPTION
## Summary

This PR substantially enhances the MCP Notion Server with auto-pagination support, three new page management tools, improved property retrieval, and extensive documentation. The changes maintain backward compatibility while simplifying the API for common use cases.

## Key Changes

### Auto-Pagination
- **`notion_query_database`** now automatically loops through all pages of results (100 per request) until exhausted, returning the complete dataset in a single response. Removed `start_cursor` and `page_size` parameters since pagination is now internal.
- **`notion_search`** implements the same auto-pagination behavior, eliminating manual cursor management.
- **`notion_retrieve_page_property_item`** auto-paginates for property types that return lists (relations, rollups, rich_text, title, people).

### New Tools
- **`notion_create_page`** — Create pages under any parent (page or database) with support for content blocks (`children`), `icon`, and `cover` image. Superset of the existing `notion_create_database_item`.
- **`notion_archive_page`** — Archive or restore a page by setting `archived` boolean.
- **`notion_retrieve_page_property_item`** — Retrieve a specific property value from a page with auto-pagination for list-type properties.

### Implementation Details
- Modified `NotionClientWrapper.queryDatabase()` to implement pagination loop internally, collecting all results before returning.
- Modified `NotionClientWrapper.search()` with the same pagination pattern.
- Added `NotionClientWrapper.createPage()` with full parameter support (parent, properties, children, icon, cover).
- Added `NotionClientWrapper.archivePage()` for page lifecycle management.
- Added `NotionClientWrapper.retrievePagePropertyItem()` with auto-pagination for paginated property types.
- Updated tool schemas in `src/types/schemas.ts` to reflect removed pagination parameters and document auto-pagination behavior.
- Updated `src/server/index.ts` tool dispatch to handle new tools and simplified argument passing.
- Updated `src/types/args.ts` interfaces to remove `start_cursor`/`page_size` from query/search and add new tool argument types.

### Documentation & Developer Experience
- Added `install.sh` — Interactive installer that checks Node.js >= 18, installs dependencies, builds the project, and outputs a ready-to-paste MCP client config. Supports non-interactive mode via `NOTION_API_TOKEN` env var.
- Added `CLAUDE.md` — Project architecture and development guide for AI-assisted contributions.
- Added `CHANGELOG.md` — Detailed changelog documenting all additions and changes.
- Added skill guides: `skills/query-database.md`, `skills/search-workspace.md`, `skills/create-update-pages.md`, `skills/work-with-blocks.md` — Practical examples for common Notion operations.
- Added agent definitions: `agents/workspace-search.md`, `agents/report-generator.md` — Workflow templates for complex tasks.
- Completely rewrote `README.md` with clearer setup instructions, quick install, environment variables table, comprehensive tool reference, and auto-pagination explanation.

### Testing
- Updated `src/client.test.ts` to verify auto-pagination behavior in `queryDatabase` and `search` with multi-page scenarios.
- Added test cases confirming pagination loops and result aggregation.

## Backward Compatibility

- Existing tools remain functional; `notion_create_database_item` is retained alongside the new `notion_create_page`.
- The removal of `start_cursor` and `page_size` from `notion_query_database` and `notion_search` is a breaking change, but the new auto-pagination behavior is simpler and more intuitive for most use cases.
- All other tool signatures remain unchanged.

https://claude.ai/code/session_01XireJfQQNCzrLk7X28GvoF