### PR TITLE
feat: add table block creation support to blockObjectSchema

### DIFF
--- a/src/mcp/schema.ts
+++ b/src/mcp/schema.ts
@@ -251,7 +251,7 @@ export const blockObjectSchema = {
     type: {
       type: "string",
       description:
-        "Type of the block. Possible values include 'paragraph', 'heading_1', 'heading_2', 'heading_3', 'bulleted_list_item', 'numbered_list_item', 'to_do', 'toggle', 'child_page', 'child_database', 'embed', 'callout', 'quote', 'equation', 'divider', 'table_of_contents', 'column', 'column_list', 'link_preview', 'synced_block', 'template', 'link_to_page', 'audio', 'bookmark', 'breadcrumb', 'code', 'file', 'image', 'pdf', 'video'. Not all types are supported for creation via API.",
+        "Type of the block. Possible values include 'paragraph', 'heading_1', 'heading_2', 'heading_3', 'bulleted_list_item', 'numbered_list_item', 'to_do', 'toggle', 'child_page', 'child_database', 'embed', 'callout', 'quote', 'equation', 'divider', 'table', 'table_row', 'table_of_contents', 'column', 'column_list', 'link_preview', 'synced_block', 'template', 'link_to_page', 'audio', 'bookmark', 'breadcrumb', 'code', 'file', 'image', 'pdf', 'video'. Not all types are supported for creation via API.",
     },
     paragraph: {
       type: "object",
@@ -556,6 +556,86 @@ export const blockObjectSchema = {
           },
         },
       },
+    },
+    table: {
+      type: "object",
+      description:
+        "Table block object. Contains table_width columns and rows of cells. The table_width is immutable after creation.",
+      properties: {
+        table_width: {
+          type: "integer",
+          description:
+            "Number of columns in the table. This value is immutable after creation.",
+        },
+        has_column_header: {
+          type: "boolean",
+          description:
+            "Whether the table has a column header row. Default is false.",
+          default: false,
+        },
+        has_row_header: {
+          type: "boolean",
+          description:
+            "Whether the table has a row header column. Default is false.",
+          default: false,
+        },
+        children: {
+          type: "array",
+          description:
+            "Array of table_row block objects representing the rows of the table.",
+          items: {
+            type: "object",
+            description: "A table_row block object.",
+            properties: {
+              type: {
+                type: "string",
+                description: "Must be 'table_row'.",
+                enum: ["table_row"],
+              },
+              table_row: {
+                type: "object",
+                description:
+                  "Table row content. Each cell is an array of rich text objects.",
+                properties: {
+                  cells: {
+                    type: "array",
+                    description:
+                      "Array of cells. Each cell is an array of rich text objects. The number of cells must match table_width.",
+                    items: {
+                      type: "array",
+                      description:
+                        "A single cell containing an array of rich text objects.",
+                      items: richTextObjectSchema,
+                    },
+                  },
+                },
+                required: ["cells"],
+              },
+            },
+            required: ["type", "table_row"],
+          },
+        },
+      },
+      required: ["table_width", "children"],
+    },
+    table_row: {
+      type: "object",
+      description:
+        "Table row block object. Each cell is an array of rich text objects.",
+      properties: {
+        cells: {
+          type: "array",
+          description:
+            "Array of cells. Each cell is an array of rich text objects.",
+          items: {
+            type: "array",
+            description:
+              "A single cell containing an array of rich text objects.",
+            items: richTextObjectSchema,
+          },
+        },
+      },
+      required: ["cells"],
     },
     divider: {
       type: "object",


### PR DESCRIPTION
## Summary

Adds `table` and `table_row` block type schemas to `blockObjectSchema` in `src/mcp/schema.ts`, enabling the `notion_append_block_children` MCP tool to create Notion table blocks programmatically.

**Closes #80**

## Changes

**File**: `src/mcp/schema.ts` (+81 lines, -1 line)

### 1. Table block schema
- `table_width` (required integer, immutable after creation)
- `has_column_header` (optional boolean, default false)
- `has_row_header` (optional boolean, default false)
- `children` (required array of `table_row` objects)

### 2. Table row block schema
- `cells` (required array of rich text arrays)
- References existing `richTextObjectSchema` for cell content

### 3. Type description updated
- Added `'table'` and `'table_row'` to the list of possible block type values

## Why

The underlying Notion REST API `PATCH /v1/blocks/{block_id}/children` fully supports table blocks natively. This change only extends the MCP schema definition — **no handler or client code changes needed** since `appendBlockChildren` already passes raw JSON blocks directly to the Notion API.

## Testing

- ✅ TypeScript compiles cleanly (`tsc --noEmit` — zero errors)
- ✅ Tested with direct Notion REST API call — table blocks created successfully
- ✅ Verified in production: https://app.notion.com/p/376c1d57-3f3f-8006-a54e-feee6bce169a (6 tables created)

## Example

```json
{
  "object": "block",
  "type": "table",
  "table": {
    "table_width": 3,
    "has_column_header": true,
    "children": [
      {
        "object": "block",
        "type": "table_row",
        "table_row": {
          "cells": [
            [{"type": "text", "text": {"content": "Header 1"}, "annotations": {"bold": true}}],
            [{"type": "text", "text": {"content": "Header 2"}, "annotations": {"bold": true}}],
            [{"type": "text", "text": {"content": "Header 3"}, "annotations": {"bold": true}}]
          ]
        }
      },
      {
        "object": "block",
        "type": "table_row",
        "table_row": {
          "cells": [
            [{"text": {"content": "Cell A"}}],
            [{"text": {"content": "Cell B"}}],
            [{"text": {"content": "Cell C"}}]
          ]
        }
      }
    ]
  }
}
```

## Reference
- Notion API table block spec: https://developers.notion.com/reference/block#table-blocks
- Notion MCP issue: #80