### PR TITLE
Fix eager evaluation crash for is_empty operator on non-text properties

### DIFF
--- a/src/tools/data-sources/query.ts
+++ b/src/tools/data-sources/query.ts
@@ -169,19 +169,9 @@ function buildTypedCondition(
       return equalsCondition(operator, expectBoolean(propertyName, value));
     case "select":
     case "status":
-      return optionCondition(
-        propertyName,
-        schema,
-        operator,
-        value,
-      );
+      return optionCondition(propertyName, schema, operator, value);
     case "multi_select":
-      return optionCondition(
-        propertyName,
-        schema,
-        operator,
-        value,
-      );
+      return optionCondition(propertyName, schema, operator, value);
     case "date":
       return dateCondition(propertyName, operator, value);
     case "relation":
@@ -279,7 +269,13 @@ function optionCondition(
     ]);
   }
 
-  return { [operator]: expectKnownOption(propertyName, schema, expectString(propertyName, value)) };
+  return {
+    [operator]: expectKnownOption(
+      propertyName,
+      schema,
+      expectString(propertyName, value),
+    ),
+  };
 }
 
 function dateCondition(

--- a/src/tools/data-sources/query.ts
+++ b/src/tools/data-sources/query.ts
@@ -173,20 +173,20 @@ function buildTypedCondition(
         propertyName,
         schema,
         operator,
-        expectString(propertyName, value),
+        value,
       );
     case "multi_select":
       return optionCondition(
         propertyName,
         schema,
         operator,
-        expectString(propertyName, value),
+        value,
       );
     case "date":
       return dateCondition(propertyName, operator, value);
     case "relation":
     case "people":
-      return containsCondition(operator, expectString(propertyName, value));
+      return containsCondition(propertyName, operator, value);
     default:
       throw new Error(
         `Property '${propertyName}' has unsupported type '${schema.type}' for simple querying. Use notion_query_data_source with raw Notion filter JSON.`,
@@ -263,7 +263,7 @@ function optionCondition(
   propertyName: string,
   schema: DatabasePropertyConfig,
   operator: SimpleFilterOperator,
-  optionName: string,
+  value: unknown,
 ): Record<string, unknown> {
   if (isEmptyOperator(operator)) return { [operator]: true };
 
@@ -279,7 +279,7 @@ function optionCondition(
     ]);
   }
 
-  return { [operator]: expectKnownOption(propertyName, schema, optionName) };
+  return { [operator]: expectKnownOption(propertyName, schema, expectString(propertyName, value)) };
 }
 
 function dateCondition(
@@ -307,8 +307,9 @@ function dateCondition(
 }
 
 function containsCondition(
+  propertyName: string,
   operator: SimpleFilterOperator,
-  value: string,
+  value: unknown,
 ): Record<string, unknown> {
   if (isEmptyOperator(operator)) return { [operator]: true };
   if (!["contains", "does_not_contain"].includes(operator)) {
@@ -316,7 +317,7 @@ function containsCondition(
       `Relation and people filters only support contains or does_not_contain, got '${operator}'.`,
     );
   }
-  return { [operator]: value };
+  return { [operator]: expectString(propertyName, value) };
 }
 
 function requirePropertySchema(


### PR DESCRIPTION
Fixes #83 

### Summary of Changes
This PR resolves a crash that occurs when using the `is_empty` or `is_not_empty` operator on properties like `select`, `status`, `multi_select`, `relation`, and `people` via the `notion_query_data_source_by_values` tool.

Previously, `expectString(propertyName, value)` was evaluated eagerly inside the `buildTypedCondition` switch statement. This caused the server to throw an `Error: Property '[Name]' must be a string.` before the downstream functions could verify if the operator was checking for an empty value (which naturally passes `undefined`).

### What was changed
* Removed the eager `expectString` wrappers from the `select`, `status`, `multi_select`, `relation`, and `people` cases in `buildTypedCondition`.
* Updated the `containsCondition` and `optionCondition` functions to accept the raw `value` and the `propertyName`.
* Deferred the `expectString` validation inside these functions until *after* the `isEmptyOperator(operator)` check returns, aligning the logic with how `textCondition` is currently handled safely.