### PR TITLE
fix: pin MCP SDK to Zod v4 compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check:fix": "biome check --write"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.11.2",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "yargs": "^17.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.11.2
+        specifier: 1.29.0
         version: 1.29.0(zod@4.4.1)
       react:
         specifier: 18.3.1


### PR DESCRIPTION
Issue: https://github.com/suekou/mcp-notion-server/issues/82

Pin `@modelcontextprotocol/sdk` to `1.29.0` so installs cannot resolve to older SDK versions that are incompatible with Zod v4.

Older SDK versions can publish empty tool input schemas and fail tool calls with:

```text
keyValidator._parse is not a function
```